### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 # PM master check, allows approval of any PR
-* @maffiemaffie


### PR DESCRIPTION
We might want to add this branch protection back in the future, but for the time being this should probably be removed (or at least changed) so current team members can manage PRs.