### PR TITLE
Settings page cleanup, credits footer consistency

### DIFF
--- a/client/src/api/data-managers/project-data-manager.ts
+++ b/client/src/api/data-managers/project-data-manager.ts
@@ -187,6 +187,8 @@ export const projectDataManager = async (projectId: number) => {
 
     // fetch new canonical data
     await reloadSavedProject();
+    console.log("New data: ");
+    console.log(savedProject);
 
     // clear changes object
     resetChanges();
@@ -249,12 +251,15 @@ export const projectDataManager = async (projectId: number) => {
 
     // project thumbnails
     try {
+
       await runAndCollectErrors<UpdateProjectThumbnailInput>(
         "Updating project thumbnail",
         [updates.thumbnail],
         ({ data }) => updateThumb(projectId, data)
       );
+
     } catch (error) {
+      console.log("Failed to update thumbnail: " + (error as { message: string }).message);
       errorMessage += (error as { message: string }).message;
     }
 
@@ -470,15 +475,11 @@ export const projectDataManager = async (projectId: number) => {
     // TODO can be ran simultaneously if saving takes too long
     // we haven't found this to be a problem.
     for (const request of requests) {
-      //unbelievable thumbnail-specific check
-      if (!(actionLabel === "Updating project thumbnail" && request.data)) {
-        const response = await action(request);
-        const succeeded = !response.error;
-        statuses.push({
-          id: request.id.value,
-          succeeded,
-        });
-      }
+      const response = await action(request);
+      statuses.push({
+        id: request.id.value,
+        succeeded: !response.error,
+      });
     }
 
     const errors = getErrorIds(statuses);

--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -213,9 +213,14 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
       return;
     }
 
+    console.log("Created project thumbnail: ");
+    console.log(modifiedProject.thumbnail);
+
     try {
         await dataManager.saveChanges();
         setProjectData(dataManager.getSavedProject());
+        console.log("Saved project: ");
+        console.log(projectData);
 
       // EXISTING PROJECT
       if (!newProject && projectID) {

--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -217,10 +217,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
     console.log(modifiedProject.thumbnail);
 
     try {
-        await dataManager.saveChanges();
-        setProjectData(dataManager.getSavedProject());
-        console.log("Saved project: ");
-        console.log(projectData);
+      await dataManager.saveChanges();
 
       // EXISTING PROJECT
       if (!newProject && projectID) {

--- a/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
@@ -73,7 +73,7 @@ export const MediaTab = ({
   useEffect(() => {
     const initializeImages = async () => {
       // if only one image or no thumbnail, set thumbnail
-      if ((projectAfterMediaChanges.projectImages.length === 1 && projectAfterMediaChanges.projectImages[0].image) || !projectAfterMediaChanges.thumbnail) {
+      if (projectAfterMediaChanges.projectImages.length >= 1 && !projectAfterMediaChanges.thumbnail) {
         // if image is a string, create file
         if (typeof projectAfterMediaChanges.projectImages[0].image === 'string') {
           const file = await stringToFile(projectAfterMediaChanges.projectImages[0].image);
@@ -167,11 +167,11 @@ export const MediaTab = ({
         ],
       };
 
-      updatePendingProject(projectAfterMediaChanges);
-
       // If only image, set as thumbnail
       //this will always be localId, it's using the recently created image
-      if (projectAfterMediaChanges.projectImages.length === 1) {
+      if (!projectAfterMediaChanges.thumbnail || projectAfterMediaChanges.projectImages.length == 1) {
+        console.log("adding thumbnail to project");
+
         // Update dataManager
         const thumbObj = {
             localId: ++localIdIncrement,
@@ -193,6 +193,7 @@ export const MediaTab = ({
           thumbnail: thumbObj,
         };
       }
+      updatePendingProject(projectAfterMediaChanges);
 
     } catch (err) {
       console.error(err);

--- a/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
@@ -170,8 +170,6 @@ export const MediaTab = ({
       // If only image, set as thumbnail
       //this will always be localId, it's using the recently created image
       if (!projectAfterMediaChanges.thumbnail || projectAfterMediaChanges.projectImages.length == 1) {
-        console.log("adding thumbnail to project");
-
         // Update dataManager
         const thumbObj = {
             localId: ++localIdIncrement,
@@ -184,7 +182,7 @@ export const MediaTab = ({
             type: "canon",
           },
           data: {
-            thumbnail: thumbObj.localId ?? ++localIdIncrement
+            thumbnail: thumbObj.localId as number
           }
         });
         // Update project data

--- a/client/src/components/ProjectPanel.tsx
+++ b/client/src/components/ProjectPanel.tsx
@@ -115,6 +115,10 @@ export const ProjectPanel = ({ project }: ProjectPanelProps) => {
       if (projectResp.data) { 
         setFollowCount(projectResp.data.followers.count);
         checkFollow();
+        if (project.title == "thumbnail") {
+          console.log("Thumbnail project's thumbnail:");
+          console.log(project.thumbnail);
+        }
       }
     };
       getProjectData();

--- a/client/src/components/Styles/credits.css
+++ b/client/src/components/Styles/credits.css
@@ -11,10 +11,16 @@ Credits link footer style rules
 */
 
 .FooterContainer {
+  display: flex;
+  position: sticky;
+  top: 96%;
+
   text-align: center;
-  align-content: center;
-  height: 100px;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
   width: 100%;
+
   z-index: 1;
   background-color: var(--header-color);
 }
@@ -22,8 +28,9 @@ Credits link footer style rules
 .FooterContainer button {
   border: 0px;
   background: 0px;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: bold;
+  margin: 2px;
 }
 
 .FooterContainer button:hover {

--- a/client/src/components/Styles/settings.css
+++ b/client/src/components/Styles/settings.css
@@ -344,7 +344,6 @@ input:checked+.slider:before {
   input {
     border: none;
     background-color: var(--header-color);
-    color: var(--neutral-gray);
     outline: none;
     width: 100%;
   }

--- a/client/src/components/pages/NewSettings.tsx
+++ b/client/src/components/pages/NewSettings.tsx
@@ -251,7 +251,7 @@ const Settings = () => {
               // Create deep copy of object, make changes, then call state update
               const tempInfo : MePrivate = JSON.parse(JSON.stringify(userInfo));
               
-              tempInfo[cleaned_type] = firstParam;
+              //tempInfo[cleaned_type] = firstParam;
               
               setUserInfo(tempInfo);
               //this isn't really needed but i'm gonna leave it anyway

--- a/client/src/components/pages/NewSettings.tsx
+++ b/client/src/components/pages/NewSettings.tsx
@@ -336,6 +336,9 @@ const Settings = () => {
                         setError('*Please enter a valid phone number.');
                         return;
                       }
+                      else {
+                        // TODO: Insert the backend connection to change the user's phone number
+                      }
                     }
 
                     if (type !== 'Password') {
@@ -540,7 +543,7 @@ const Settings = () => {
                   <div className="input-container">
                     <input
                       id="option-primary-phone"
-                      placeholder={'111-111-1111'}
+                      placeholder={'123-123-1234'}
                       type="text"
                       disabled
                     />

--- a/client/src/components/pages/NewSettings.tsx
+++ b/client/src/components/pages/NewSettings.tsx
@@ -565,7 +565,7 @@ const Settings = () => {
                   <Dropdown>
                     <DropdownButton buttonId="options-theme-btn">
                       <div className="input-container">
-                        <input id="option-theme" placeholder={themeOption} type="text" disabled />
+                        <p id="option-theme">{themeOption}</p>
                         <ThemeIcon
                           id={'dropdown-arrow'}
                           width={15}


### PR DESCRIPTION
Cleaned up the settings page so all of the interactive elements function as expected.

Additionally, I modified the styling on the credits footer to keep it on the bottom of the page, even if there isn't enough content to fill up the page (like on the settings screen).