### PR TITLE
Redirect on project creation despite backend being down

### DIFF
--- a/client/src/api/data-managers/project-data-manager.ts
+++ b/client/src/api/data-managers/project-data-manager.ts
@@ -246,21 +246,24 @@ export const projectDataManager = async (projectId: number) => {
         ({ id, data }) => updatePic(projectId, id.value, data)
       );
     } catch (error) {
-      errorMessage += (error as { message: string }).message;
+      // Don't fail completely. This should probably be reverted as AWS is set up
+      console.warn("Skipped updating images (backend may be down):", (error as { message: string }).message);
     }
 
     // project thumbnails
     try {
 
-      await runAndCollectErrors<UpdateProjectThumbnailInput>(
-        "Updating project thumbnail",
-        [updates.thumbnail],
-        ({ data }) => updateThumb(projectId, data)
-      );
+      // Only update if there is a thumbnail
+      if (updates.thumbnail && updates.thumbnail.data && updates.thumbnail.data.thumbnail !== undefined) {
+        await runAndCollectErrors<UpdateProjectThumbnailInput>(
+          "Updating project thumbnail",
+          [updates.thumbnail],
+          ({ data }) => updateThumb(projectId, data)
+        );
+      }
 
     } catch (error) {
-      console.log("Failed to update thumbnail: " + (error as { message: string }).message);
-      errorMessage += (error as { message: string }).message;
+      console.warn("Skipped updating images (backend may be down):", (error as { message: string }).message);
     }
 
     // project socials

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -1,5 +1,5 @@
 // import { profiles } from "../../constants/fakeData";
-import { useState, useMemo, ChangeEvent } from 'react';
+import { useState, useMemo, ChangeEvent, useEffect } from 'react';
 // import { PagePopup, openClosePopup } from "../PagePopup";
 import ToTopButton from '../ToTopButton';
 import CreditsFooter from '../CreditsFooter';
@@ -121,9 +121,10 @@ const MyProjects = () => {
   //   }
   // };
 
-  if (!dataLoaded) {
+  // React likes this more than a boolean check
+  useEffect(() => {
     getUserProjects();
-  }
+  }, []);
   // else {
   //     if (projectsList.length < 20) {
   //         let tempList = new Array(0);
@@ -504,7 +505,9 @@ const MyProjects = () => {
 
           {/*Create Project Button*/}
           <div className="my-projects-create-btn">
-            <ProjectCreatorEditor newProject={true}/>
+            <ProjectCreatorEditor 
+              newProject={true}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
When making a new project, it originally redirected the user to their new project. Since we are migrating to AWS, it used to throw an error when updating the thumbnail since the old image backend is down. This lets it still redirect even though the image backend is down