### PR TITLE
Use absolute paths instead of relative

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,7 +28,7 @@ import { ThemeContext } from './contexts/ThemeContext';
 import uselocalstorage from 'use-local-storage';
 
 function App() {
-  //const [avatarImage, setAvatarImage] = useState('images/tempProfilePic.png'); -- Commented in clean up 26-20-01 
+  //const [avatarImage, setAvatarImage] = useState('/images/tempProfilePic.png'); -- Commented in clean up 26-20-01 
   const [profileImage, setProfileImage] = useState('');
 
   // https://css-tricks.com/easy-dark-mode-and-multiple-color-themes-in-react/

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -134,9 +134,9 @@ export const Header : React.FC<HeaderProps> = ({ dataSets, onSearch, value = "",
           <DropdownButton buttonId="notif-btn">
             // If implementing, use SVG sprite sheet instead of hard-coded pngs
             <img
-              src="assets/bell_dark.png"
-              src-light="assets/bell_light.png"
-              src-dark="assets/bell_dark.png"
+              src="/assets/bell_dark.png"
+              src-light="/assets/bell_light.png"
+              src-dark="/assets/bell_dark.png"
               alt="" />
           </DropdownButton>
           <DropdownContent rightAlign={true}>This is where notification stuff will be</DropdownContent>

--- a/client/src/components/PagePopup.tsx
+++ b/client/src/components/PagePopup.tsx
@@ -111,7 +111,7 @@ export const PagePopup = ({
               openClosePopup(show, setShow);
             }}
           >
-            <img src="images/icons/cancel.png" alt="cancel" />
+            <img src="/images/icons/cancel.png" alt="cancel" />
           </button>
           {children}
         </div>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -296,9 +296,9 @@ const SideBar = () => {
           {/* <button className={activePage === 'Following' ? 'active' : ''} onClick={() => handleTextChange('Following', paths.routes.SETTINGS)}>
             // If implementing, use SVG sprite sheet instead of hard-coded png
             <img
-              src="assets/following.png"
-              src-light="assets/following.png"
-              src-dark="assets/following.png"
+              src="/assets/following.png"
+              src-light="/assets/following.png"
+              src-dark="/assets/following.png"
               alt="" /> Following
           </button> */}
 
@@ -307,7 +307,7 @@ const SideBar = () => {
           </button> */}
 
           {/*           {/* <button className={activePage === 'Messages' ? 'active' : ''} onClick={() => handleTextChange('Messages', paths.routes.MESSAGES)}>
-          <img src="images/icons/nav/msg-nav.png" className="navIcon" alt="Messages" /> Messages
+          <img src="/images/icons/nav/msg-nav.png" className="navIcon" alt="Messages" /> Messages
           </button> */}
         </div>
 

--- a/client/src/components/SignupProcess/GetStarted.tsx
+++ b/client/src/components/SignupProcess/GetStarted.tsx
@@ -33,11 +33,11 @@ const GetStarted : React.FC<GetStartedProps> = ({ show, onBack, onCreateProject,
           <div id="getStarted-select">
             <button id="new-project-btn" onClick={onCreateProject}>
               Create Project
-              <img src="images/icons/nav/projects.png" alt="folder" />
+              <img src="/images/icons/nav/projects.png" alt="folder" />
             </button>
             <button id="join-project-btn" onClick={onJoinProject}>
               Join Project
-              <img src="images/icons/nav/discover.png" alt="compass" />
+              <img src="/images/icons/nav/discover.png" alt="compass" />
             </button>
           </div>
 

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -37,8 +37,8 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
           <div id="profile-hero">
             <div id="profile-hero-blurb-1" className="profile-hero-blurb">
               <ThemeImage
-                lightSrc={'assets/bannerImages/people1_light.png'}
-                darkSrc={'assets/bannerImages/people1_dark.png'}
+                lightSrc={'/assets/bannerImages/people1_light.png'}
+                darkSrc={'/assets/bannerImages/people1_dark.png'}
                 id={'profile-hero-img-1'}
                 alt={'banner image'}
               />
@@ -50,8 +50,8 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
             <div id="profile-hero-blurb-2" className="profile-hero-blurb">
               {/* <h2>Look for people to work with!</h2> */}
               <ThemeImage
-                lightSrc={'assets/bannerImages/people2_light.png'}
-                darkSrc={'assets/bannerImages/people2_dark.png'}
+                lightSrc={'/assets/bannerImages/people2_light.png'}
+                darkSrc={'/assets/bannerImages/people2_dark.png'}
                 id={'profile-hero-img-2'}
                 alt={'banner image'}
               />
@@ -64,8 +64,8 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
 
             <div id="profile-hero-blurb-3" className="profile-hero-blurb">
               <ThemeImage
-                lightSrc={'assets/bannerImages/people3_light.png'}
-                darkSrc={'assets/bannerImages/people3_dark.png'}
+                lightSrc={'/assets/bannerImages/people3_light.png'}
+                darkSrc={'/assets/bannerImages/people3_dark.png'}
                 id={'profile-hero-img-3'}
                 alt={'banner image'}
               />

--- a/client/src/components/pages/ForgotPassword.tsx
+++ b/client/src/components/pages/ForgotPassword.tsx
@@ -114,8 +114,8 @@ const ForgotPassword: React.FC = () => {
           {/* <h1>Welcome!</h1>
                     <p>Don't have an account?</p> */}
           <ThemeImage
-            lightSrc={'assets/bannerImages/login_light.png'}
-            darkSrc={'assets/bannerImages/login_dark.png'}
+            lightSrc={'/assets/bannerImages/login_light.png'}
+            darkSrc={'/assets/bannerImages/login_dark.png'}
           />
           <button onClick={() => navigate(paths.routes.SIGNUP)}>Sign Up</button>
         </div>

--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -222,8 +222,8 @@ const Login: React.FC = () => {
           {/* <h1>Welcome!</h1>
                     <p>Don't have an account?</p> */}
           <ThemeImage
-            lightSrc={'assets/bannerImages/login_light.png'}
-            darkSrc={'assets/bannerImages/login_dark.png'}
+            lightSrc={'/assets/bannerImages/login_light.png'}
+            darkSrc={'/assets/bannerImages/login_dark.png'}
           />
           <button onClick={() => navigate(paths.routes.SIGNUP)}>Sign Up</button>
         </div>

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -389,8 +389,8 @@ const MyProjects = () => {
     <div className="projects-banner-outer">
     <div className="projects-banner-wrapper">
       <ThemeImage
-        lightSrc={'assets/projects_header_light.png'}
-        darkSrc={'assets/projects_header_dark.png'}
+        lightSrc={'/assets/projects_header_light.png'}
+        darkSrc={'/assets/projects_header_dark.png'}
         className={'my-projects-banner'}
         alt={'My Projects Banner'}
       />

--- a/client/src/components/pages/NewSettings.tsx
+++ b/client/src/components/pages/NewSettings.tsx
@@ -643,8 +643,8 @@ const Settings = () => {
                           disabled
                         />
                         <ThemeIcon
-                          src={'assets/dropdown_light.svg'}
-                          darkSrc={'assets/dropdown_dark.svg'}
+                          src={'/assets/dropdown_light.svg'}
+                          darkSrc={'/assets/dropdown_dark.svg'}
                           alt={'Visibility'}
                           addClass={'options-dropdown-parent-btn'}
                         />

--- a/client/src/components/pages/NotFound.tsx
+++ b/client/src/components/pages/NotFound.tsx
@@ -18,8 +18,8 @@ const NotFoundPage = () => {
             <Header dataSets={projectsList} onSearch={currentSearch} />
             <div className="error-box">
                 <ThemeImage
-                    lightSrc={'assets/bannerImages/404_light.png'}
-                    darkSrc={'assets/bannerImages/404_dark.png'}
+                    lightSrc={'/assets/bannerImages/404_light.png'}
+                    darkSrc={'/assets/bannerImages/404_dark.png'}
                     id={'error-image'}
                     alt={'404 Not Found'}
                 />

--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -264,7 +264,7 @@ const Settings = () => {
               <div className="row displayName">
                 <input type="text" placeholder="myDisplayedName" value="" />
                 {/* TODO: check this matches design */}
-                <img src="images/icons/pencil.png" alt="pencil icon" />
+                <img src="/images/icons/pencil.png" alt="pencil icon" />
               </div>
             </div>
           </div>

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -433,8 +433,8 @@ const SignUp = ({ /*setAvatarImage, avatarImage,*/ profileImage, setProfileImage
           {/* <h1>Welcome!</h1>
                     <p>Already have an account?</p> */}
           <ThemeImage
-            lightSrc={'assets/bannerImages/signup_light.png'}
-            darkSrc={'assets/bannerImages/signup_dark.png'}
+            lightSrc={'/assets/bannerImages/signup_light.png'}
+            darkSrc={'/assets/bannerImages/signup_dark.png'}
           />
           <button onClick={() => navigate(paths.routes.LOGIN)}>Log In</button>
         </div>


### PR DESCRIPTION
I changed all of the image sources to use absolute paths instead of relative. This fixes images not loading on a page with a trailing slash
<img width="1615" height="678" alt="image" src="https://github.com/user-attachments/assets/5c9719a2-372c-46d4-a69a-adb02d26289b" />
