### PR TITLE
Fix project panel clipping

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -93,7 +93,7 @@ Project Panel component style rules
 
 .project-panel-hover {
   border-radius: 0 0 10px 10px;
-  background-color: var(--bg-color);
+  background-color: var(--header-color);
   /* box-shadow: 2px 2px 10px 2px var(--shadow-color); */
   color: var(--main-text);
   position: absolute;

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -99,7 +99,8 @@ Project Panel component style rules
   position: absolute;
   height: auto;
   /* min-width: 420px; */
-  width: 100%;
+  left: 0px;
+  right: 0px;
   top: 100%;
   pointer-events: none;
   visibility: visible;

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -76,7 +76,9 @@ Project Panel component style rules
   transition: 0.2s;
   border-radius: 10px 10px 0 0;
   cursor: pointer;
-  box-shadow: 2px 2px 10px 2px var(--shadow-color);
+  /* box-shadow: 2px 2px 10px 2px var(--shadow-color); */
+  filter: drop-shadow(2px 2px 10px var(--shadow-color));
+  z-index: 2;
 
   img {
     border-radius: 10px 10px 0 0;
@@ -92,7 +94,7 @@ Project Panel component style rules
 .project-panel-hover {
   border-radius: 0 0 10px 10px;
   background-color: var(--bg-color);
-  box-shadow: 2px 2px 10px 2px var(--shadow-color);
+  /* box-shadow: 2px 2px 10px 2px var(--shadow-color); */
   color: var(--main-text);
   position: absolute;
   height: auto;


### PR DESCRIPTION
https://github.com/user-attachments/assets/b4d2ffc4-c501-4055-b9a5-8cd94a8b70ab

Changed some styling to fix:
- right side of project-panel-hover juts out
- project-panel-hover bg darker than project-panel bg
- box-shadows overlapping between project-panel:hover and project-panel-hover