### PR TITLE
Signup/Login Reworks

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 // Styles
 import './components/Styles/master.css';
 // Components and pages
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import * as paths from './constants/routes';
 import { useState } from 'react';
 import Login from './components/pages/Login';
@@ -35,6 +35,10 @@ function App() {
   const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const [theme, setTheme] = uselocalstorage('theme', defaultDark ? 'dark' : 'light');
 
+  const location = useLocation();
+  const sidebarlessPages = ['/login', '/signup', '/forgotPassword'];
+  const hideSidebar = sidebarlessPages.includes(location.pathname);
+
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>
       <div className="App" data-theme={theme}>
@@ -49,7 +53,7 @@ function App() {
         >
           Skip to main content
         </a>
-        <SideBar /*avatarImage={avatarImage} setAvatarImage={setAvatarImage} theme={theme}  -- Commented in clean up 26-20-01 */ />
+        {!hideSidebar && <SideBar /*avatarImage={avatarImage} setAvatarImage={setAvatarImage} theme={theme}  -- Commented in clean up 26-20-01 */ />}
         <Routes>
           <Route path={paths.routes.DEFAULT} element={<Discover />} />
           <Route path={paths.routes.LOGIN} element={<Login />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -38,7 +38,15 @@ function App() {
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>
       <div className="App" data-theme={theme}>
-        <a href="#main" className="skip-link" tabIndex={1}>
+        <a 
+          href="#main" 
+          className="skip-link" 
+          tabIndex={1}
+          onClick={(e) => {
+            e.preventDefault();
+            document.getElementById('main')?.focus();
+          }}
+        >
           Skip to main content
         </a>
         <SideBar /*avatarImage={avatarImage} setAvatarImage={setAvatarImage} theme={theme}  -- Commented in clean up 26-20-01 */ />

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -27,27 +27,26 @@ Login and Signup page style rules
 }
 
 .login-signup-container {
+  width: 95%;
+  max-width: 880px;
   margin: auto;
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  height: 525px;
-  width: min(95vw,880px);
   background-color: var(--bg-color);
   box-shadow: 0px 0px 10px 0px var(--shadow-color);
   border-radius: 10px;
   position: relative;
+  overflow: hidden;
 }
 
 .login-form,
-.signup-form {
-  width: min(95vw,440px);
+.signup-form,
+.directory {
+  flex: 1;
   height: 485px;
   text-align: center;
   /* border: 1px solid black; */
   background-color: var(--bg-color);
-  padding: 20px;
+  padding: 40px 20px;
   border-radius: 10px 0 0 10px;
   display: flex;
   flex-direction: column;
@@ -57,20 +56,11 @@ Login and Signup page style rules
 }
 
 .directory {
-  width: 440px;
-  height: 485px;
-  text-align: center;
   /* border: 1px solid black; */
   background: var(--sidebar-gradient);
   color: var(--main-text);
-  padding: 20px;
-  border-radius: 0 10px 10px 0;
   background-size: cover;
   background-position: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
 }
 
 .directory img {
@@ -99,24 +89,11 @@ Login and Signup page style rules
   margin-bottom: 0;
 } */
 
-.signup-name-input {
-  width: min(40vw,135px);
-  height: 40px;
-  margin: 5px;
-  padding: 5px 20px;
-  border: none;
-  outline: none;
-  background-color: var(--header-color);
-  border-radius: 10px;
-  text-align: left;
-  font-size: 0.9375rem;
-}
-
 .signup-input,
-.login-input {
-  width: min(90vw,320px);
+.login-input,
+.signup-name-input {
+  width: 100%; 
   height: 40px;
-  margin: 5px;
   padding: 5px 20px;
   border: none;
   background-color: var(--header-color);
@@ -125,6 +102,7 @@ Login and Signup page style rules
   text-align: left;
   outline: none;
   font-size: 0.9375rem;
+  box-sizing: border-box;
 }
 
 .signup-input::placeholder,
@@ -169,25 +147,28 @@ Login and Signup page style rules
   transition: 0.2s;
 }
 
-.login-form-inputs {
-  /* border: 1px solid black; */
-  /* height: 300px; */
-  margin: 10px 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  max-width: 100%;
-}
-
 .signup-form-inputs {
   /* border: 1px solid black; */
+  width: 100%;
+  max-width: 320px;
   height: 340px;
-  margin: 10px 0;
+  margin: 20px 0;
+  gap: 15px;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
+}
+
+.signup-form-inputs .row {
+  display: flex;
+  gap: 15px;
+  width: 100%;
+}
+
+.signup-name-input {
+  flex: 1;
+  min-width: 0;
 }
 
 #password-wrapper {
@@ -198,13 +179,13 @@ Login and Signup page style rules
 
 #password-wrapper input {
   padding-right: 60px;
-  width: min(90vw,280px);
+  width: 100%;
 }
 
 #show-password {
   position: absolute;
   top: 55%;
-  right: 22px;
+  right: 0.5rem;
   transform: translateY(-50%);
   border: none;
   background-color: transparent;
@@ -239,6 +220,7 @@ Login and Signup page style rules
 }
 
 .spacer {
+  border-bottom: 1px solid var(--primary-color);
   /* height: 30px; */
 }
 

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -152,7 +152,8 @@ Login and Signup page style rules
   /* border: 1px solid black; */
   width: 100%;
   max-width: 320px;
-  height: 340px;
+  max-height: 340px;
+  height: auto;
   margin: 20px 0;
   gap: 15px;
   display: flex;
@@ -253,8 +254,13 @@ Login and Signup page style rules
 
   .login-form,
   .signup-form {
-    position: fixed;
+    position: relative;
     border-radius: 4px;
+
+    width: 100%;
+    max-width: 400px; 
+    height: auto;
+    margin: 0 auto;
   }
 
   .directory {

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -147,7 +147,8 @@ Login and Signup page style rules
   transition: 0.2s;
 }
 
-.signup-form-inputs {
+.signup-form-inputs,
+.login-form-inputs {
   /* border: 1px solid black; */
   width: 100%;
   max-width: 320px;
@@ -173,12 +174,12 @@ Login and Signup page style rules
 
 #password-wrapper {
   position: relative;
-  display: inline-block;
+  width: 100%;
   margin: 0px;
 }
 
 #password-wrapper input {
-  padding-right: 60px;
+  padding-right: 45px;
   width: 100%;
 }
 
@@ -217,6 +218,12 @@ Login and Signup page style rules
 
 #forgot-password:hover {
   text-decoration: underline;
+}
+
+#forgot-password,
+.mobile-signup,
+.mobile-login {
+  align-self: center;
 }
 
 .spacer {

--- a/client/src/components/ThemeIcon.tsx
+++ b/client/src/components/ThemeIcon.tsx
@@ -34,6 +34,20 @@ export const ThemeIcon: React.FC<ThemeIconProps> = memo(({
   onClick = undefined
 }) => {
 
+  const handleKeyDown = (e: React.KeyboardEvent<SVGSVGElement>) => {
+    if (!onClick) 
+      return;
+
+    // SVG doesn't natively override these.
+    // If this is on a page with a form, like login, trying to hit enter while focused
+    // On the back button will try to submit the form. This fixes that
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onClick(e as unknown as React.MouseEvent<SVGSVGElement>);
+    }
+  };
+
   return (
     <svg
       width={width}
@@ -41,7 +55,9 @@ export const ThemeIcon: React.FC<ThemeIconProps> = memo(({
       id={id}
       className={className}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       aria-label={ariaLabel}
+      tabIndex={onClick ? 0 : -1}
     >
       <use href={`${source}#${id}`} xlinkHref={`${source}#${id}`} />
     </svg>

--- a/client/src/components/pages/ForgotPassword.tsx
+++ b/client/src/components/pages/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import * as paths from '../../constants/routes';
-import { ThemeImage } from '../ThemeIcon';
+import { ThemeIcon, ThemeImage } from '../ThemeIcon';
 import { sendPost } from '../../functions/fetch.js';
 import { getUserByEmail } from '../../api/users.js';
 
@@ -84,6 +84,14 @@ const ForgotPassword: React.FC = () => {
 
                 *************************************************************/}
         <div className="login-form column">
+          <ThemeIcon //Back button to return to the previous page
+            id={'back'}
+            width={70}
+            height={25}
+            className={'color-fill'}
+            ariaLabel={'back'}
+            onClick={handleBackToLogin}
+          />
           <h2>Forgot password?</h2>
           <p>No worries! We'll send you reset instructions.</p>
           <div className="login-form-inputs">
@@ -97,10 +105,6 @@ const ForgotPassword: React.FC = () => {
               value={emailInput}
               onChange={(e) => setEmailInput(e.target.value)}
             />
-
-            <button id="forgot-password" onClick={handleBackToLogin}>
-              Back to Login
-            </button>
           </div>
           <button id="main-loginsignup-btn" onClick={handleSend}>
             Send

--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -187,7 +187,7 @@ const Login: React.FC = () => {
             }}
           />
           <h2>Log In</h2>
-          <div className="error">{error}</div>
+          <div className="error" aria-live="assertive" role="alert">{error}</div>
           <div className="login-form-inputs">
             <input
               id='main'

--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 import { sendPost } from '../../functions/fetch.js';
 import { ThemeIcon, ThemeImage } from '../ThemeIcon';
-import { getUserByEmail, getUserByUsername } from '../../api/users.js';
+import { getCurrentUsername, getUserByEmail, getUserByUsername } from '../../api/users.js';
 
 type LoginResponse = {
   error?: string;
@@ -25,6 +25,21 @@ const Login: React.FC = () => {
   const [password, setPassword] = useState<string>('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
+
+  // Redirect the user to the homepage if they are currently logged in
+  useEffect(() => {
+    const checkSessionAndRedirect = async () => {
+      try {
+        const res = await getCurrentUsername();
+        if (res.data)
+          navigate(paths.routes.HOME);
+      } catch (err) {
+        console.error("Session check failed:", err);
+      }
+    };
+
+    checkSessionAndRedirect();
+  }, [navigate]);
 
   /**
    * Validates user inputs, sends login requests to the server API, and handles authentication

--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -26,6 +26,8 @@ const Login: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
 
+  const [isLoading, setIsLoading] = useState(false);
+
   // Redirect the user to the homepage if they are currently logged in
   useEffect(() => {
     const checkSessionAndRedirect = async () => {
@@ -47,6 +49,9 @@ const Login: React.FC = () => {
    * @returns false if an error occurred.
    */
   const handleLogin = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
     // Check if the loginInput and password are not empty
     if (loginInput === '' || password === '') {
       setError('Please fill in all information');
@@ -132,6 +137,7 @@ const Login: React.FC = () => {
     // {
     //   navigate(paths.routes.CREATEPROJECT);
     // }
+    setIsLoading(false);
   };
 
   /**
@@ -225,8 +231,8 @@ const Login: React.FC = () => {
               </p>
             </div>
           </div>
-          <button id="main-loginsignup-btn" onClick={handleLogin}>
-            Log In
+          <button id="main-loginsignup-btn" onClick={handleLogin} disabled={isLoading}>
+            {isLoading ? 'Loading...' : 'Log In'}
           </button>
         </div>
         {/*************************************************************

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -79,7 +79,7 @@ const MyProjects = () => {
       }
 
     } catch (e) {
-      console.error('error getting projecrs', e);
+      console.error('error getting projects', e);
       setCreateError(true);
     }
 

--- a/client/src/components/pages/ResetPassword.tsx
+++ b/client/src/components/pages/ResetPassword.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { sendPost } from '../../functions/fetch';
 import passwordValidator from 'password-validator';
+import { getCurrentUsername } from '../../api/users';
+import { routes } from '../../constants/routes';
 
 /**
  * Reset Password page. Renders a secure, interactive form that allows the user to input
@@ -18,6 +20,21 @@ const ResetPassword = () => {
   const [confirmInput, setConfirmInput] = useState('');
   const [error, setError] = useState(''); // Error message for missing or incorrect information
   const [passwordMsg, setPasswordMsg] = useState('');
+
+  // Redirect the user to the homepage if they are currently logged in
+  useEffect(() => {
+    const checkSessionAndRedirect = async () => {
+      try {
+        const res = await getCurrentUsername();
+        if (res.data)
+          navigate(routes.HOME);
+      } catch (err) {
+        console.error("Session check failed:", err);
+      }
+    };
+
+    checkSessionAndRedirect();
+  }, [navigate]);
 
   /**
    * Checks the logic for submitting a new password.

--- a/client/src/components/pages/ResetPassword.tsx
+++ b/client/src/components/pages/ResetPassword.tsx
@@ -138,7 +138,7 @@ const ResetPassword = () => {
       <div className="login-form column">
         <h2>Set new password</h2>
         <div className="login-form-inputs">
-          <div className="error">{error}</div>
+          <div className="error" aria-live="assertive" role="alert">{error}</div>
           <span id="errorMessage"></span>
           <input
             className="login-input"

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 // import MakeAvatarModal from '../AvatarCreation/MakeAvatarModal';
@@ -9,7 +9,7 @@ import CompleteProfile from '../SignupProcess/CompleteProfile';
 import GetStarted from '../SignupProcess/GetStarted';
 import { ThemeIcon, ThemeImage } from '../ThemeIcon';
 import passwordValidator from 'password-validator';
-import { getUserByEmail, getUserByUsername } from '../../api/users';
+import { getCurrentUsername, getUserByEmail, getUserByUsername } from '../../api/users';
 
 /**
  * Sign up page. Records user input, validates user-given information with server data, and records it to server if valid.
@@ -62,6 +62,21 @@ const SignUp = ({ /*setAvatarImage, avatarImage,*/ profileImage, setProfileImage
     // avatarImage: avatarImage,
     profileImage: profileImage, // if they upload their own image
   };
+
+  // Redirect the user to the homepage if they are currently logged in
+  useEffect(() => {
+    const checkSessionAndRedirect = async () => {
+      try {
+        const res = await getCurrentUsername();
+        if (res.data)
+          navigate(paths.routes.HOME);
+      } catch (err) {
+        console.error("Session check failed:", err);
+      }
+    };
+
+    checkSessionAndRedirect();
+  }, [navigate]);
 
   /**
    * Goes through the various fields, verifies whether user input is valid, and sends it to the server.

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -249,7 +249,7 @@ const SignUp = ({ /*setAvatarImage, avatarImage,*/ profileImage, setProfileImage
 
           <h2>Sign Up</h2>
 
-          <div className="error">{message}</div>
+          <div className="error" aria-live="assertive" role="alert">{message}</div>
           <div className="signup-form-inputs">
             <div className="row">
               <input


### PR DESCRIPTION
This PR makes a lot of changes to the sign-up and log-in pages
## Conditional Sidebar
The sidebar used to always be visible, which was a nightmare for accessibility
<img width="1917" height="2115" alt="image" src="https://github.com/user-attachments/assets/f209bef6-e79b-4a60-ae10-8b440536c8eb" />
<img width="1917" height="2115" alt="image" src="https://github.com/user-attachments/assets/4ce2845f-ae70-49be-ace9-bd07accaaf09" />
## Better Formatting
Mobile as well as desktop formatting is consistent, and the layout of log-in, sign-up, and forgot password are consistent with one another
<img width="1917" height="2115" alt="image" src="https://github.com/user-attachments/assets/75eedf63-18cf-47dc-97fc-896e7cfe237a" />
<img width="1917" height="2115" alt="image" src="https://github.com/user-attachments/assets/0d448d7a-44f0-4350-8399-8d9caa03b98a" />
## Redirect if User is Logged In
This prevents users from being able to navigate to these pages, considering logged in users can't log in again
## Better Tab Navigation
Every page now has each visible button on its tab list. It used to be that you were unable to access the back button on a screen reader
## Alerts for Screen Readers
Errors while logging in or signing up will now read out to users on a screen reader. Screen readers used to be unable to see errors