### PR TITLE
Added word breaks to about this project

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -3175,6 +3175,11 @@ button#positions-popup-list-item-active {
   margin-bottom: 20px;
 }
 
+#project-overview-text {
+  word-break: break-word;
+  hyphens: auto;
+}
+
 .project-overview-section-header {
   font-size: 1rem;
   color: var(--primary-color);


### PR DESCRIPTION
#603 
<img width="985" height="418" alt="image" src="https://github.com/user-attachments/assets/fbd323c4-673c-410b-a193-83f8b9b81b73" />

- added word breaks prevent page from extending way too long, while keeping the integrity of regular text
- forces hyphenated text split only on larger words