### PR TITLE
Modified the filter categories to not move the others when hovered over

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1061,18 +1061,27 @@ Page popup style rules
     /* Indicate should be clicked without being a button */
     cursor: pointer;
     transition: 0.2s;
+    padding: 1px;
     /* margin: 14px 38px; */
+    width: 12%;
+    text-align: center
   }
 
   .filter-tab:hover {
     color: var(--primary-color);
     font-weight: 600;
     transition: none;
+    padding: 1px;
+    width: 12%;
+    text-align: center
   }
 
   .filter-tab.selected {
     font-weight: 700;
     color: var(--primary-color);
+    padding: 1px;
+    width: 12%;
+    text-align: center
   }
 
   hr {


### PR DESCRIPTION
Changed the filter categories in the  project filters page so that they don't shift the others to the left and right when hovered over