### PR TITLE
Fixed the project filters tags being from the wrong tab sometimes

### DIFF
--- a/client/src/components/DiscoverFilters.tsx
+++ b/client/src/components/DiscoverFilters.tsx
@@ -60,6 +60,8 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
   const [activeTagFilters, setActiveTagFilters] = useState<Tag[]>([]);
   // Whether the "Applied Filters" section should display under the quick tags
   const [displayFiltersText, setDisplayFiltersText] = useState(false);
+  //Keeps track of the currently selected tab in this popup.
+  const [activeTabId, setActiveTabId] = useState(0);
 
   // Dynamically show/hide arrows
   const tagFiltersRef = useRef<HTMLDivElement>(null);
@@ -167,6 +169,15 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
   useEffect(() => {
     if (!dataLoaded) getData();
   }, [dataLoaded]);
+  //Displays the correct tabs depending on the value of activeTabId.
+  useEffect(() => {
+    if(filterPopupTabs[activeTabId]) {
+      const currentTab = filterPopupTabs[activeTabId];
+      setCurrentTags(currentTab.categoryTags);
+      setDataSet([{ data: currentTab.categoryTags }]);
+      setSearchedTags({ tags: currentTab.categoryTags, color: currentTab.color });
+    }
+  }, [activeTabId, filterPopupTabs]);
 
   /**
    * Toggles a tag's selection in the horizontal quick filter.
@@ -245,15 +256,15 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
    */
   const setupFilters = () => {
     // Defaults to the first available tab
-    if (filterPopupTabs.length > 0) {
-      const firstTab = filterPopupTabs[0];
-      setCurrentTags(firstTab.categoryTags);
-      setDataSet([{ data: firstTab.categoryTags }]);
-      setSearchedTags({
-        tags: firstTab.categoryTags,
-        color: firstTab.color,
-      });
-    }
+    //if (filterPopupTabs.length > 0) {
+    //  const currentTab = filterPopupTabs[activeTabId];
+    //  setCurrentTags(currentTab.categoryTags);
+    //  setDataSet([{ data: currentTab.categoryTags }]);
+    //  setSearchedTags({
+    //    tags: currentTab.categoryTags,
+    //    color: currentTab.color,
+    //  });
+    //}
     setEnabledFilters([]);
   };
 
@@ -325,19 +336,19 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
                     {filterPopupTabs.map((tab, index) => (
                       <a
                         key={`${tab.categoryName}-${index}`}
-                        className={`filter-tab ${index === 0 ? 'selected' : ''}`}
-                        onClick={(e) => {
-                          const element = e.target as HTMLElement;
+                        className={`filter-tab ${index === activeTabId ? 'selected' : ''}`}
+                        onClick={() => {
+                          //const element = e.target as HTMLElement;
 
-                          // Remove .selected from all 3 options, add it only to current button
-                          const tabs = document.querySelector('#filter-tabs')!.children;
-                          for (let i = 0; i < tabs.length; i++) {
-                            tabs[i].classList.remove('selected');
-                          }
-                          element.classList.add('selected');
-                          setCurrentTags(tab.categoryTags);
-                          setDataSet([{ data: tab.categoryTags }]);
-                          setSearchedTags({ tags: tab.categoryTags, color: tab.color });
+                          //// Remove .selected from all 3 options, add it only to current button
+                          //const tabs = document.querySelector('#filter-tabs')!.children;
+                          //for (let i = 0; i < tabs.length; i++) {
+                          //  tabs[i].classList.remove('selected');
+                          //}
+                          //element.classList.add('selected');
+
+                          //Sets the index to the setActiveId value.
+                          setActiveTabId(index);
                         }}
                       >
                         {tab.categoryName}


### PR DESCRIPTION
On the project filters popup, the correct tags for the current tab show up even after closing and reopening the filter popup.