### PR TITLE
enabled a popup confirmation to close project editor without saving

### DIFF
--- a/client/src/components/Popup.tsx
+++ b/client/src/components/Popup.tsx
@@ -104,6 +104,7 @@ PopupButton = ({
  * @param useClose — show close button (default true)
  * @param callback — function to run on closing
  * @param profilePopup — variant style for profile popups
+ * @param confirmation — if true, does not disable popup but still runs callback (default false)
  * @returns JSX.Element | null popup overlay and content
  */
 export const PopupContent = ({
@@ -113,6 +114,7 @@ export const PopupContent = ({
   profilePopup = false,
   closeButtonRef = undefined,
   openFocusRef = undefined,
+  confirmation = false,
 }: {
   children: ReactNode;
   useClose?: boolean;
@@ -120,6 +122,7 @@ export const PopupContent = ({
   profilePopup?: false | true;
   closeButtonRef?: React.RefObject<null>;
   openFocusRef?: React.RefObject<HTMLElement | null>;
+  confirmation?: boolean;
 }) => {
   const { open, setOpen } = useContext(PopupContext);
   const popupRef = useRef(null);
@@ -127,7 +130,7 @@ export const PopupContent = ({
   // Close the popup and execute optional callback
   const closePopup = useCallback(() => {
     callback();
-    setOpen(false);
+    if(!confirmation) setOpen(false);
   }, [callback, setOpen]);
 
   // Close on Escape key press

--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -80,6 +80,8 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
   // Tracks whether the project was successfully saved (prevents deletion on cleanup after save)
   const [saved, setSaved] = useState(false);
 
+  const [confirm, setConfirm] = useState(false);
+
   // Component Refs
   const exitButton = useRef(null);
   const startButton = useRef(null);
@@ -201,7 +203,6 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
 
   //this deletes the newly created project when the create window is manually closed
   //this is called below as the PopupContent's callback function (that only calls when it's closed so should it just be called onClose?)
-  //TODO: update this to show a close without saving prompt
   const closeWithoutSaving = async () => {
     // Why is this here? If it's a new project then it won't be on the API anyway
     setCurrentTab(0);
@@ -209,6 +210,9 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
     if(projectData && newProject && !saved) await deleteProject(projectData?.projectId);
   }
 
+  const toggleConfirm = async () => {
+    setConfirm(!confirm);
+  }
 
   // Isn't this what createoredit is supposed to do? it never calls this though
   /**
@@ -289,7 +293,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
   const updatePendingProject = (updatedPendingProject: PendingProject) => {
     setModifiedProject(updatedPendingProject);
   }
-
+  
   return (
     <Popup>
       {newProject ? (
@@ -310,8 +314,18 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
         </PopupButton>
       )}
 
-      <PopupContent callback={closeWithoutSaving} closeButtonRef={exitButton}>
-        
+      <PopupContent callback={toggleConfirm} closeButtonRef={exitButton} confirmation={true}>
+        {confirm ? <PopupContent confirmation={true} useClose={false}>
+          <div id="confirm-editor-save-text">Are you sure you want to exit without saving?</div>
+          <div id="confirm-editor-save">
+            <PopupButton doNotClose={() => false} callback={closeWithoutSaving} buttonId="project-editor-save">
+              Confirm
+            </PopupButton>
+            <PopupButton doNotClose={() => true} callback={toggleConfirm} buttonId="team-edit-member-cancel-button" >
+              Cancel
+            </PopupButton>
+          </div>
+        </PopupContent> : ""}
         <div id="project-creator-editor">
           <div id="project-editor-tabs">
             <button


### PR DESCRIPTION
also allows any popupContent to do the same with the confirmation attribute

### popup uses the same style as the save confirmation
<img width="1092" height="834" alt="image" src="https://github.com/user-attachments/assets/9f3793da-7d25-4865-ba8d-ceeecc8e0f24" />

to enable this a new optional attribute was added to the popupContent element called confirmation, details of which have been added to Fronted Documentation