### PR TITLE
Fixed setting all projects invisible throws a 404

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -25,6 +25,7 @@ export const GET = async (apiURL: string): Promise<ApiResponse> => {
         : `?devId=${import.meta.env.VITE_DEV_ID}`;
     }
 
+    //404 when all projects are set to invisible
     const response = await fetch(url, {
       method: "GET",
       credentials: "include",

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -25,7 +25,6 @@ export const GET = async (apiURL: string): Promise<ApiResponse> => {
         : `?devId=${import.meta.env.VITE_DEV_ID}`;
     }
 
-    //404 when all projects are set to invisible
     const response = await fetch(url, {
       method: "GET",
       credentials: "include",

--- a/client/src/api/users.ts
+++ b/client/src/api/users.ts
@@ -61,9 +61,9 @@ export const getCurrentUsername = async (): Promise<UsernameResponse> => {
     data:
       response.status === 200
         ? {
-            userId: (response.data as MePrivate).userId,
-            username: (response.data as MePrivate).username,
-          }
+          userId: (response.data as MePrivate).userId,
+          username: (response.data as MePrivate).username,
+        }
         : undefined,
     error: response.error,
   };
@@ -271,7 +271,7 @@ export const updateProjectVisibility = async (
   });
 
   // if (response.error)
-    //console.log(`Error in updateProjectVisibility: ${response.error}`);
+  //console.log(`Error in updateProjectVisibility: ${response.error}`);
   //console.log(response);
   return response as ApiResponse<MyMember>;
 };

--- a/server/src/services/users/get-user-proj.ts
+++ b/server/src/services/users/get-user-proj.ts
@@ -25,7 +25,8 @@ export const getUserProjectsService = async (
       select: ProjectPreviewSelector,
     });
 
-    if (projects.length === 0) return 'NOT_FOUND';
+    //So invisible projects don't throw a 404
+    if (projects.length === 0) return [];
 
     const result = projects.map(transformProjectToPreview);
 


### PR DESCRIPTION
If projects.length === 0, it now returns [] instead of 'NOT_FOUND'.

Issue URL: https://github.com/orgs/LookingforGrp-rit/projects/7/views/1?pane=issue&itemId=190555851&issue=LookingforGrp-rit%7CLookingForGroup%7C678