### PR TITLE
Fix 404 when there is no projects to display

### DIFF
--- a/server/src/services/users/get-user-proj.ts
+++ b/server/src/services/users/get-user-proj.ts
@@ -25,7 +25,7 @@ export const getUserProjectsService = async (
       select: ProjectPreviewSelector,
     });
 
-    if (projects.length === 0) return 'NOT_FOUND';
+    //if (projects.length === 0) return 'NOT_FOUND';
 
     const result = projects.map(transformProjectToPreview);
 

--- a/server/src/services/users/get-user-proj.ts
+++ b/server/src/services/users/get-user-proj.ts
@@ -11,6 +11,14 @@ export const getUserProjectsService = async (
   userId: number,
 ): Promise<ProjectPreview[] | GetProjectsError> => {
   try {
+    //check that user exists
+    const user = await prisma.users.findUnique({
+      where: {
+        userId,
+      },
+    });
+    if (user === null) return 'NOT_FOUND';
+
     //get projects that a user is publicly a member of
     const projects = await prisma.projects.findMany({
       where: {


### PR DESCRIPTION
api/users/{id}/projects does not give a 404 if there are no public projects to display. It will only do so if the user doesn't exist