### PR TITLE
Fixed multi toggle issue on discover page filters

### DIFF
--- a/client/src/components/DiscoverFilters.tsx
+++ b/client/src/components/DiscoverFilters.tsx
@@ -171,18 +171,22 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
    */
   const toggleTag = (event: any, tag: Tag) => {
     let newActiveTags: Tag[];
-    const button = event.currentTarget;
-    button.classList.toggle('discover-tag-filter-selected');
+    
+    const discoverFilters = document.getElementsByClassName('discover-tag-filter');
+    for (let i = 0; i < discoverFilters.length; i++) {
+      discoverFilters[i].classList.remove('discover-tag-filter-selected');
+    }
 
     if (activeTagFilters.some(t => t.label === tag.label && t.type === tag.type)) {
-      newActiveTags = activeTagFilters.filter(t => t.label !== tag.label || t.type !== tag.type);
+      newActiveTags = []; 
     } else { 
-      newActiveTags = [...activeTagFilters, tag];
+      newActiveTags = [tag]; 
+      event.currentTarget.classList.add('discover-tag-filter-selected');
     }
 
     setActiveTagFilters(newActiveTags);
     updateItemList(newActiveTags);
-  };
+};
 
   /**
    * Scrolls horizontal tag list left or right.


### PR DESCRIPTION
Fixed the issue on discover page where "Project Type" filters that are visible being able to be multiselected despite these category of filter lacking that functionality. I just edited it to make it so only one filter option can be selected at a time.

The actually functionality of the filter may still need to get implemented, this just changes how the buttons work.