### PR TITLE
fixed oversight for quiting without saving

### DIFF
--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -401,7 +401,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, buttonCallback = (
         </PopupButton>
       )}
 
-      <PopupContent callback={toggleConfirm} closeButtonRef={exitButton} confirmation={!saved}>
+      <PopupContent callback={saved ? toggleConfirm : closeWithoutSaving} closeButtonRef={exitButton} confirmation={!saved}>
         {confirm ? <PopupContent confirmation={true} useClose={false}>
           <div id="confirm-editor-save-text">Are you sure you want to exit without saving?</div>
           <div id="confirm-editor-save">


### PR DESCRIPTION
yesterday I put a change to allow bypass of the quit confirmation if the user hadn't made changes but I neglected to re-add the quit without saving function to the bypass.