### PR TITLE
Unified Project Hover Transition

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -67,7 +67,7 @@ Project Panel component style rules
   .project-panel-hover {
     visibility: hidden;
     opacity: 0;
-    transition: visibility 0s, opacity 0.2s;
+    transition: visibility 0.2s, opacity 0.2s;
     z-index: 15;
   }
 }


### PR DESCRIPTION
It used to transition the heart counter in and out and the rest would instantly appear and disappear