### PR TITLE
Fixed footer from being pushed down too far

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -246,7 +246,7 @@ section {
 .my-projects-grid,
 .my-projects-list,
 #discover-panel-box {
-  min-height: 50vh;
+  min-height: 35vh;
 }
 
 /* #endregion */


### PR DESCRIPTION
#743 

- Fixed issue by reducing spacing for footers on pages
  - Looks fine on all affected pages (discover, my projects in grid and list view)