### PR TITLE
Fixed the invalid text position on the team and links pages

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -970,6 +970,7 @@ Project Creator and Editor Popup style rules
 
 #team-save-info {
   display: flex;
+  flex-direction: column;
   align-items: center;
   margin-top: auto;
 }
@@ -1599,6 +1600,7 @@ select.edit-position-compensation {
 /* Project Editor/Creator Links Tab */
 #link-save-info {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   margin-top: auto;
 }


### PR DESCRIPTION
Somebody forgot to set the flexbox to vertical. That's it.

This finishes #746 .