### PR TITLE
Long hook messing up project panels on hover #748

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -115,6 +115,8 @@ Project Panel component style rules
   text-align: left;
   gap: 6px;
   padding: 14px 0;
+  word-break: break-word;
+  hyphens: auto;
 
   img {
     /* width: 100%; */

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -101,7 +101,7 @@ Project Panel component style rules
   right: 0px;
   bottom: 0;
   height: auto;
-  max-height: 100%;
+  max-height: 96%;
   /* min-width: 420px; */
   visibility: visible;
   transition: visibility 0.2s;
@@ -114,7 +114,7 @@ Project Panel component style rules
   justify-content: start;
   text-align: left;
   gap: 6px;
-  padding: 14px 0;
+  padding: 2% 0;
   word-break: break-word;
   hyphens: auto;
 

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -101,7 +101,7 @@ Project Panel component style rules
   right: 0px;
   bottom: 0;
   height: auto;
-  max-height: 96%;
+  max-height: 86%;
   /* min-width: 420px; */
   visibility: visible;
   transition: visibility 0.2s;
@@ -114,9 +114,10 @@ Project Panel component style rules
   justify-content: start;
   text-align: left;
   gap: 6px;
-  padding: 2% 0;
+  padding: 3% 0;
   word-break: break-word;
   hyphens: auto;
+  overflow-y: scroll;
 
   img {
     /* width: 100%; */
@@ -195,10 +196,9 @@ Project Panel component style rules
     color: var(--main-text);
     font-size: 0.875rem;
     font-weight: 400;
-    line-height: 28px;
+    line-height: 20px;
 
     min-height: 0;
-    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
#748 
<img width="927" height="316" alt="image" src="https://github.com/user-attachments/assets/3969b1c8-fdb0-4857-9ce5-7c1ccb03409f" />

- Now contains all information within the panel area
- If too much text exists, user will have to scroll
  - Not ideal but better than before
  - Will likely need to be revisited in the future and decided on how to continue, long hooks have been causing problems