### PR TITLE
Created unit tests for /projects/socials and /projects/members

### DIFF
--- a/server/tests/projectstest/members/add-member.test.ts
+++ b/server/tests/projectstest/members/add-member.test.ts
@@ -1,0 +1,90 @@
+import type {
+  CreateProjectMemberInput,
+  ProjectMember,
+  UserPreview,
+} from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { MembersProfileVisibility } from '#prisma-models/index.js';
+import addMemberService from '#services/projects/members/add-member.ts';
+import { transformProjectMember } from '#services/transformers/projects/parts/project-member.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    members: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-member.ts', () => ({
+  transformProjectMember: vi.fn(),
+}));
+
+const data: CreateProjectMemberInput = {
+  userId: 29,
+  roleId: 31,
+};
+
+const now = new Date();
+
+const testMember = {
+  projectId: 1,
+  userId: 29,
+  roleId: 31,
+  profileVisibility: 'Public' as MembersProfileVisibility,
+  createdAt: now,
+};
+
+const transformedMember: ProjectMember = {
+  user: { userId: 29 } as UserPreview,
+  role: {
+    roleId: 31,
+    label: 'Test',
+  },
+  memberSince: now,
+  apiUrl: 'api/project/1/members/29',
+};
+
+describe('addProjectMemberService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the member when add is successful', async () => {
+    vi.mocked(prisma.members.create).mockResolvedValue(testMember);
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await addMemberService(1, data);
+
+    expect(transformProjectMember).toBeCalled();
+    expect(transformProjectMember).toBeCalledWith(1, testMember);
+    expect(result).toBe(transformedMember);
+  });
+  it("returns NOT_FOUND when it can't find the right data", async () => {
+    vi.mocked(prisma.members.create).mockRejectedValue({ code: 'P2025' });
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await addMemberService(1, data);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it('returns CONFLICT when there is a conflict', async () => {
+    vi.mocked(prisma.members.create).mockRejectedValue({ code: 'P2002' });
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await addMemberService(1, data);
+
+    expect(result).toBe('CONFLICT');
+  });
+
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.members.create).mockRejectedValue(new Error('womp womp'));
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await addMemberService(1, data);
+
+    expect(result).toBe('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/members/delete-member.test.ts
+++ b/server/tests/projectstest/members/delete-member.test.ts
@@ -1,0 +1,67 @@
+import type { ProjectPurpose, ProjectStatus } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { deleteMemberService } from '#services/projects/members/delete-member.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    projects: {
+      findUnique: vi.fn(),
+    },
+    members: {
+      delete: vi.fn(),
+    },
+  },
+}));
+const now = new Date();
+const prismaProject = {
+  audience: '',
+  createdAt: now,
+  description: '',
+  hook: '',
+  projectId: 100,
+  purpose: 'Academic' as ProjectPurpose,
+  status: 'Planning' as ProjectStatus,
+  thumbnailId: 8,
+  title: 'test 1',
+  updatedAt: now,
+  userId: 1,
+};
+
+describe('addProjectMemberService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns NO_CONTENT when delete is successful', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
+    const result = await deleteMemberService(100, 29);
+
+    expect(result).toBe('NO_CONTENT');
+  });
+
+  it('returns NOT_FOUND if the request attempts to delete the owner', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
+    const result = await deleteMemberService(100, 1);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it("returns NOT_FOUND if the project isn't found", async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(null);
+    const result = await deleteMemberService(100, 29);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR if prisma throws', async () => {
+    vi.mocked(prisma.projects.findUnique).mockRejectedValue(new Error('womp womp'));
+    const result = await deleteMemberService(100, 29);
+
+    expect(result).toBe('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/members/get-members.test.ts
+++ b/server/tests/projectstest/members/get-members.test.ts
@@ -1,0 +1,101 @@
+import type { ProjectMember, UserPreview } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { MembersProfileVisibility } from '#prisma-models/index.js';
+import getMemberService from '#services/projects/members/get-members.ts';
+import { transformProjectMember } from '#services/transformers/projects/parts/project-member.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment*/
+/* eslint-disable @typescript-eslint/no-unsafe-call*/
+/* eslint-disable @typescript-eslint/no-unsafe-member-access*/
+/* eslint-disable @typescript-eslint/restrict-template-expressions*/
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    members: {
+      findMany: vi.fn(),
+    },
+    majors: {
+      findMany: vi.fn(),
+    },
+    users: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-member.ts', () => ({
+  transformProjectMember: vi.fn(),
+}));
+
+const now = new Date();
+
+const testMembers = [
+  {
+    projectId: 1,
+    userId: 29,
+    roleId: 31,
+    label: 'Test',
+    profileVisibility: 'Public' as MembersProfileVisibility,
+    createdAt: now,
+  },
+  {
+    projectId: 1,
+    userId: 76,
+    roleId: 52,
+    label: 'Test 2',
+    profileVisibility: 'Public' as MembersProfileVisibility,
+    createdAt: now,
+  },
+];
+
+const transformedMembers: ProjectMember[] = [
+  {
+    user: { userId: 29 } as UserPreview,
+    role: {
+      roleId: 31,
+      label: 'Test',
+    },
+    memberSince: now,
+    apiUrl: '/api/projects/1/members/29',
+  },
+  {
+    user: { userId: 76 } as UserPreview,
+    role: {
+      roleId: 52,
+      label: 'Test 2',
+    },
+    memberSince: now,
+    apiUrl: '/api/projects/1/members/76',
+  },
+];
+
+describe('getProjectMemberService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (transformProjectMember as Mock).mockImplementation(
+      (projectId, { userId, roleId, label, createdAt }): ProjectMember => {
+        return {
+          user: { userId: userId } as UserPreview,
+          role: {
+            roleId: roleId,
+            label: label,
+          },
+          memberSince: createdAt,
+          apiUrl: `/api/projects/${projectId.toString()}/members/${userId.toString()}`,
+        };
+      },
+    );
+  });
+
+  it('returns the members when get is successful', async () => {
+    vi.mocked(prisma.members.findMany).mockResolvedValue(testMembers);
+    const result = await getMemberService(1);
+
+    expect(transformProjectMember).toBeCalled();
+    expect(transformProjectMember).toBeCalledTimes(2);
+    expect(result).toStrictEqual(transformedMembers);
+  });
+});

--- a/server/tests/projectstest/members/update-member.test.ts
+++ b/server/tests/projectstest/members/update-member.test.ts
@@ -1,0 +1,88 @@
+import type { ProjectMember, UserPreview } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { MembersProfileVisibility } from '#prisma-models/index.js';
+import updateMemberService from '#services/projects/members/update-member.ts';
+import { transformProjectMember } from '#services/transformers/projects/parts/project-member.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    members: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-member.ts', () => ({
+  transformProjectMember: vi.fn(),
+}));
+
+const data = {
+  profileVisibility: 'Private' as MembersProfileVisibility,
+};
+
+const now = new Date();
+
+const testMember = {
+  projectId: 1,
+  userId: 29,
+  roleId: 31,
+  profileVisibility: 'Public' as MembersProfileVisibility,
+  createdAt: now,
+};
+
+const updatedMember = {
+  projectId: 1,
+  userId: 29,
+  roleId: 31,
+  profileVisibility: 'Private' as MembersProfileVisibility,
+  createdAt: now,
+};
+
+const transformedMember: ProjectMember = {
+  user: { userId: 29 } as UserPreview,
+  role: {
+    roleId: 31,
+    label: 'Test',
+  },
+  memberSince: now,
+  apiUrl: 'api/project/1/members/29',
+};
+
+describe('updateProjectMemberService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the member when update is successful', async () => {
+    vi.mocked(prisma.members.findUnique).mockResolvedValue(testMember);
+    vi.mocked(prisma.members.update).mockResolvedValue(updatedMember);
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await updateMemberService({ projectId: 100, userId: 29 }, data);
+
+    expect(transformProjectMember).toBeCalled();
+    expect(result).toBe(transformedMember);
+  });
+  it("returns NOT_FOUND when member isn't found", async () => {
+    vi.mocked(prisma.members.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.members.update).mockResolvedValue(updatedMember);
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await updateMemberService({ projectId: 100, userId: 29 }, data);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.members.findUnique).mockRejectedValue(new Error('womp womp'));
+    vi.mocked(prisma.members.update).mockResolvedValue(updatedMember);
+    vi.mocked(transformProjectMember).mockReturnValue(transformedMember);
+    const result = await updateMemberService({ projectId: 100, userId: 29 }, data);
+
+    expect(result).toBe('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/socials/add-social.test.ts
+++ b/server/tests/projectstest/socials/add-social.test.ts
@@ -1,0 +1,61 @@
+import type { AddProjectSocialInput, ProjectSocial } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { addProjectSocialService } from '#services/projects/socials/add-social.ts';
+import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    socials: {
+      findFirst: vi.fn(),
+    },
+    projectSocials: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-social.ts', () => ({
+  transformProjectSocial: vi.fn(),
+}));
+
+const data: AddProjectSocialInput = {
+  websiteId: 29,
+  url: 'www.test.com',
+};
+
+const testSocial = {
+  projectId: 1,
+  websiteId: 29,
+  url: 'www.test.com',
+  label: 'Test',
+};
+
+const transformedSocial: ProjectSocial = {
+  websiteId: 29,
+  url: 'www.test.com',
+  label: 'Test',
+  apiUrl: 'api/project/1/socials/29',
+};
+
+describe('addProjectSocialService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns the social when add is successful', async () => {
+    vi.mocked(prisma.socials.findFirst).mockResolvedValue({ websiteId: 29, label: 'Test' });
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await addProjectSocialService(data, 1);
+
+    expect(transformProjectSocial).toBeCalled();
+    expect(transformProjectSocial).toBeCalledWith(1, testSocial);
+    expect(result).toBe(transformedSocial);
+  });
+});

--- a/server/tests/projectstest/socials/add-social.test.ts
+++ b/server/tests/projectstest/socials/add-social.test.ts
@@ -58,4 +58,35 @@ describe('addProjectSocialService', async () => {
     expect(transformProjectSocial).toBeCalledWith(1, testSocial);
     expect(result).toBe(transformedSocial);
   });
+  it("returns NOT_FOUND when websiteId isn't found", async () => {
+    vi.mocked(prisma.socials.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await addProjectSocialService(data, 1);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+  it('returns CONFLICT when social already exists', async () => {
+    vi.mocked(prisma.socials.findFirst).mockResolvedValue({ websiteId: 29, label: 'Test' });
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue({
+      websiteId: 29,
+      projectId: 1,
+      url: 'www.test.com',
+    });
+    vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await addProjectSocialService(data, 1);
+
+    expect(result).toBe('CONFLICT');
+  });
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.socials.findFirst).mockRejectedValue(new Error('womp womp'));
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await addProjectSocialService(data, 1);
+
+    expect(result).toBe('INTERNAL_ERROR');
+  });
 });

--- a/server/tests/projectstest/socials/delete-proj-social.test.ts
+++ b/server/tests/projectstest/socials/delete-proj-social.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { deleteProjectSocialService } from '#services/projects/socials/delete-proj-social.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    projectSocials: {
+      findFirst: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+describe('deleteProjectSocialService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns NO_CONTENT when add is successful', async () => {
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue({
+      websiteId: 29,
+      projectId: 1,
+      url: 'www.test.com',
+    });
+    const result = await deleteProjectSocialService(29, 1);
+
+    expect(result).toBe('NO_CONTENT');
+  });
+
+  it("returns NOT_FOUND when the social doesn't exist", async () => {
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
+    const result = await deleteProjectSocialService(29, 1);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.projectSocials.findFirst).mockRejectedValue(new Error('womp womp'));
+    const result = await deleteProjectSocialService(29, 1);
+
+    expect(result).toBe('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/socials/get-proj-socials.test.ts
+++ b/server/tests/projectstest/socials/get-proj-socials.test.ts
@@ -1,0 +1,89 @@
+import type { ProjectSocial, ProjectPurpose, ProjectStatus } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import prisma from '#config/prisma.ts';
+import getProjectSocialsService from '#services/projects/socials/get-proj-socials.ts';
+import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    projects: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-social.ts', () => ({
+  transformProjectSocial: vi.fn(),
+}));
+
+const now = new Date();
+
+const testSocial1 = {
+  websiteId: 29,
+  url: 'www.test.com',
+  label: 'Test',
+};
+
+const testSocial2 = {
+  websiteId: 42,
+  url: 'www.test2.com',
+  label: 'Test 2',
+};
+
+const prismaProject = {
+  audience: '',
+  createdAt: now,
+  description: '',
+  hook: '',
+  projectId: 100,
+  purpose: 'Academic' as ProjectPurpose,
+  status: 'Planning' as ProjectStatus,
+  thumbnailId: 8,
+  title: 'test 1',
+  updatedAt: now,
+  userId: 1,
+  projectSocials: [testSocial1, testSocial2],
+};
+
+const transformedSocials: ProjectSocial[] = [
+  {
+    websiteId: 29,
+    url: 'www.test.com',
+    label: 'Test',
+    apiUrl: '/api/projects/1/socials/29',
+  },
+  {
+    websiteId: 42,
+    url: 'www.test2.com',
+    label: 'Test 2',
+    apiUrl: '/api/projects/1/socials/42',
+  },
+];
+
+describe('getProjectSocialsService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (transformProjectSocial as Mock).mockImplementation(
+      (projectId: number, { url, websiteId, label }) => ({
+        label: label,
+        websiteId: websiteId,
+        url: url,
+        apiUrl: `/api/projects/${projectId.toString()}/socials/${websiteId.toString()}`,
+      }),
+    );
+  });
+  it('returns the social when add is successful', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
+    const result = await getProjectSocialsService(1);
+
+    expect(transformProjectSocial).toBeCalled();
+    expect(transformProjectSocial).toBeCalledTimes(2);
+    expect(result).toEqual(transformedSocials);
+  });
+});

--- a/server/tests/projectstest/socials/get-proj-socials.test.ts
+++ b/server/tests/projectstest/socials/get-proj-socials.test.ts
@@ -9,6 +9,7 @@ import { transformProjectSocial } from '#services/transformers/projects/parts/pr
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/restrict-template-expressions*/
 
 vi.mock('#config/prisma.ts', () => ({
   default: {

--- a/server/tests/projectstest/socials/get-proj-socials.test.ts
+++ b/server/tests/projectstest/socials/get-proj-socials.test.ts
@@ -78,12 +78,26 @@ describe('getProjectSocialsService', async () => {
       }),
     );
   });
-  it('returns the social when add is successful', async () => {
+  it('returns the socials when get is successful', async () => {
     vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
     const result = await getProjectSocialsService(1);
 
     expect(transformProjectSocial).toBeCalled();
     expect(transformProjectSocial).toBeCalledTimes(2);
     expect(result).toEqual(transformedSocials);
+  });
+
+  it("returns NOT_FOUND when project doesn't exist", async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(null);
+    const result = await getProjectSocialsService(1);
+
+    expect(result).toEqual('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.projects.findUnique).mockRejectedValue(new Error('womp womp'));
+    const result = await getProjectSocialsService(1);
+
+    expect(result).toEqual('INTERNAL_ERROR');
   });
 });

--- a/server/tests/projectstest/socials/update-proj-social.test.ts
+++ b/server/tests/projectstest/socials/update-proj-social.test.ts
@@ -1,0 +1,68 @@
+import type { ProjectSocial } from '@looking-for-group/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { updateProjectSocialService } from '#services/projects/socials/update-proj-social.ts';
+import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    projectSocials: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('#services/transformers/projects/parts/project-social.ts', () => ({
+  transformProjectSocial: vi.fn(),
+}));
+
+const transformedSocial: ProjectSocial = {
+  websiteId: 29,
+  url: 'www.test.com',
+  label: 'Test',
+  apiUrl: '/api/projects/1/socials/29',
+};
+
+const testSocial = {
+  projectId: 1,
+  websiteId: 29,
+  url: 'www.test.com',
+};
+
+describe('getProjectSocialsService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns the social when update is successful', async () => {
+    vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await updateProjectSocialService('www.test.com', 1, 29);
+
+    expect(transformProjectSocial).toBeCalled();
+    expect(result).toEqual(transformedSocial);
+  });
+
+  it("returns NOT_FOUND when social doesn't exist", async () => {
+    vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await updateProjectSocialService('www.test.com', 1, 29);
+
+    expect(result).toEqual('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR when prisma throws', async () => {
+    vi.mocked(prisma.projectSocials.findUnique).mockRejectedValue(new Error('womp womp'));
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+    const result = await updateProjectSocialService('www.test.com', 1, 29);
+
+    expect(result).toEqual('INTERNAL_ERROR');
+  });
+});


### PR DESCRIPTION
These tests check that the backend services related to a project's socials and members work properly, and that they can handle exceptions gracefully