### PR TITLE
Project filters now dont shift around when hovering on desktop

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1117,7 +1117,6 @@ Page popup style rules
     gap: min(3.87vh, 38px) min(2.51vw, 38px);
     justify-content: center;
     margin: min(1.63vh, 16px) auto;
-    width: 90%;
   }
 
   .filter-tab {


### PR DESCRIPTION
It was caused by running out of space on the line