### PR TITLE
fixed overflow in mobile view sidebar

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -628,7 +628,6 @@ Sidebar Nav style rules
 }
 
 
-
 .containerButtonSideBar>button.active {
   background-color: var(--primary-color);
   transition: 0.25s;
@@ -787,6 +786,14 @@ Sidebar Nav style rules
     width: 15vw;
     height: 45px;
     margin: 0 5px 20px 5px;
+  }
+
+  /*temporary, until mobile sidebar layout is decided on*/
+  #about-sidebar-btn {
+    display: none;
+  }
+
+  .containerButtonSideBar>button {
     padding-left: calc((100vw - 160px) / 14);
     padding-right: calc((100vw - 160px) / 14);
   }
@@ -811,7 +818,7 @@ Sidebar Nav style rules
 
 @media only screen and (max-width: 500px) {
   .containerButtonSideBar {
-    gap: 10px;
+    gap: 5px;
   }
 }
 
@@ -1185,6 +1192,7 @@ Page popup style rules
   .popup-back {
     margin: 2.01vw 0 0 2.01vw !important;
   }
+
   .popup #filters-popup {
     h2 {
       margin-top: 3.76vh;
@@ -1204,7 +1212,7 @@ Page popup style rules
     #filter-tabs {
       column-gap: 5vw;
     }
-    
+
     #selected-section {
       width: 72vw;
       height: 19.7vh;


### PR DESCRIPTION
NOTE: i've temporarily set the display for the about button in the sidebar (mobile view) as 'none' in general.css in order to maintain even spacing + to have an odd number of buttons; once the layout for the sidebar is decided upon, this will be undone