### PR TITLE
Changed the names of the people filters to be more descriptive, also removed "soft" and "other" filters from meet

### DIFF
--- a/client/src/components/DiscoverFilters.tsx
+++ b/client/src/components/DiscoverFilters.tsx
@@ -292,8 +292,8 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
           {tagList.map(tagLabel => {
             const label = tagLabel === 'Developers' ? 'Developer' : 
               tagLabel === 'Designers' ? 'Designer' : 
-              tagLabel === 'Audio Engineers' ? 'Audio' : 
-              tagLabel === 'Software Engineers' ? "Soft" :
+              tagLabel === 'Audio Creators' ? 'Audio' : 
+              tagLabel === 'Soft Skills' ? "Soft" :
               tagLabel;
             const type = category === 'projects' ? 'Project Type' : tagLabel === 'Other' ? 'Major' : 'Role';
             const tagObj: Tag = { tagId: 0, label, type };

--- a/client/src/components/DiscoverFilters.tsx
+++ b/client/src/components/DiscoverFilters.tsx
@@ -293,7 +293,7 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
             const label = tagLabel === 'Developers' ? 'Developer' : 
               tagLabel === 'Designers' ? 'Designer' : 
               tagLabel === 'Audio Creators' ? 'Audio' : 
-              tagLabel === 'Soft Skills' ? "Soft" :
+              //tagLabel === 'Soft Skills' ? "Soft" :
               tagLabel;
             const type = category === 'projects' ? 'Project Type' : tagLabel === 'Other' ? 'Major' : 'Role';
             const tagObj: Tag = { tagId: 0, label, type };

--- a/client/src/constants/tags.ts
+++ b/client/src/constants/tags.ts
@@ -157,7 +157,7 @@ export const desSkills = [
   'Clip Studio Paint',
 ];
 
-export const peopleTags = ['Developers', 'Designers', 'Audio Engineers', 'Software Engineers', 'Other'];
+export const peopleTags = ['Developers', 'Designers', 'Audio Creators', 'Soft Skills', 'Other'];
 
 //Used for profiles and position listings on projects
 export const proficiencies = [

--- a/client/src/constants/tags.ts
+++ b/client/src/constants/tags.ts
@@ -157,7 +157,7 @@ export const desSkills = [
   'Clip Studio Paint',
 ];
 
-export const peopleTags = ['Developers', 'Designers', 'Audio Creators', 'Soft Skills', 'Other'];
+export const peopleTags = ['Developers', 'Designers', 'Audio Creators'/*, 'Soft Skills', 'Other'*/];
 
 //Used for profiles and position listings on projects
 export const proficiencies = [


### PR DESCRIPTION
For some reason the people filters in dev are called "Audio Engineers" for audio skills, and "Software Engineers" for soft skills.

"Audio Engineering" is a skill in the list, and the spread of audio skills included are not adequately described by "audio engineer".

Also "Software Engineering" for soft skills doesn't make any sense. It is not accurate in the slightest for soft skills. Soft skills are learning/job skills. Actual software engineers would be under "developers".