### PR TITLE
Profile edit popup now no longer has an empty window by default

### DIFF
--- a/client/src/components/Profile/ProfileEditPopup.tsx
+++ b/client/src/components/Profile/ProfileEditPopup.tsx
@@ -26,7 +26,7 @@ const pageTabs = ["About", "Projects", "Skills", "Links"];
  * @returns JSX Element
  */
 export const ProfileEditPopup = () => {
-  const [currentTab, setCurrentTab] = useState(5);
+  const [currentTab, setCurrentTab] = useState(0);
   const [errorVisible, setErrorVisible] = useState(false);
   const [modifiedProfile, setModifiedProfile] = useState<PendingUserProfile>();
   const [unmodifiedProfile, setUnmodifiedProfile] = useState<MePrivate>();


### PR DESCRIPTION
For some reason the popup wanted to open tab 5. There is no tab 5. Loads the About tab by default like it does in all other circumstances.