### PR TITLE
Purpose and Target Audience sections of a project now don't show if they aren't filled in

### DIFF
--- a/client/src/components/pages/Project.tsx
+++ b/client/src/components/pages/Project.tsx
@@ -482,12 +482,20 @@ const Project = () => {
               <div id="project-overview-text">{displayedProject.description}</div>
               {/* Sections could also be added with some extra function, 
             title and content can be assigned to similar elements */}
-              <div className="project-overview-section-header">Purpose</div>
-              <div>{displayedProject.purpose}</div>
-              <div className="project-overview-section-header">
-                Target Audience
-              </div>
-              <div>{displayedProject.audience}</div>
+              {displayedProject.purpose && (
+                <>
+                  <div className="project-overview-section-header">Purpose</div>
+                  <div>{displayedProject.purpose}</div>
+                </>
+              )}
+              {displayedProject.audience?.trim() && (
+                <>
+                  <div className="project-overview-section-header">
+                    Target Audience
+                  </div>
+                  <div>{displayedProject.audience}</div>
+                </>
+              )}
               <div id="project-overview-links-section">
                 {displayedProject.projectSocials.length > 0 ? (
                   <>


### PR DESCRIPTION
More specifically, if Purpose is not set to any of the values in the dropdown (which in this case leaves it as null), then the header and the "content" is not shown at all.

If the Target Audience field is either 1) not filled out, 2) an empty string, or 3) only whitespace, then the header and the content is not shown at all.

This is for the project page.