### PR TITLE
 Fixed issue where the 'learn more' button overlaps with the project tags in the discover carousel

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -338,7 +338,8 @@ Image carousel style rules
   justify-content: start;
   gap: 10px;
   margin-top: 10px;
-  width: max(70%);
+  margin-bottom: 40px;
+  width: max(100%);
 }
 
 .carousel-tag p {


### PR DESCRIPTION
I came up with a solution that works (making sure the tags are padded from the bottom enough so that the button can always fit underneath), but idk if it looks scuffed or not, so I would like a second pair of eyes to check that it looks good at all widths.