### PR TITLE
Made the Google Sign In and Sign Up Buttons more readable and visible

### DIFF
--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 import { sendPost, sendGet } from '../../functions/fetch.js';
 import { ThemeIcon, ThemeImage } from '../ThemeIcon';
 import { getCurrentUsername, getUserByEmail, getUserByUsername } from '../../api/users.js';
+import { ThemeContext } from '../../contexts/ThemeContext';
 
 type LoginResponse = {
   error?: string;
@@ -24,6 +25,7 @@ const Login: React.FC = () => {
   const [loginInput, setLoginInput] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
+  const { theme } = useContext(ThemeContext); //The theme value from ThemeContext.
 
   useEffect(() => {
     const checkSessionAndRedirect = async () => {
@@ -45,10 +47,23 @@ const Login: React.FC = () => {
       callback: handleGoogle,
     });
 
+    //Sets the string for the Google Sign In button.
+    let googleBtnTheme = new String("");
+
+    if(theme == 'dark'){
+      googleBtnTheme = "filled_black";
+    }
+    else if(theme == 'light'){
+      googleBtnTheme = "outline";
+    }
+    else{
+      googleBtnTheme = "filled_blue";
+    }
+
     // @ts-expect-error google
     google.accounts.id.renderButton(
       document.getElementById("googleBtn"),
-      { theme: "filled_black", size: "large" , shape: 'pill'}
+      { theme: googleBtnTheme, size: "large" , shape: 'pill'}
     );
 
   }, [navigate])

--- a/client/src/components/pages/Login.tsx
+++ b/client/src/components/pages/Login.tsx
@@ -50,12 +50,15 @@ const Login: React.FC = () => {
     //Sets the string for the Google Sign In button.
     let googleBtnTheme = new String("");
 
+    //If we're in dark mode, we use filled_black.
     if(theme == 'dark'){
       googleBtnTheme = "filled_black";
     }
+    //Light mode uses outline.
     else if(theme == 'light'){
       googleBtnTheme = "outline";
     }
+    //The filled_blue option shows up in case something goes wrong.
     else{
       googleBtnTheme = "filled_blue";
     }

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 // import MakeAvatarModal from '../AvatarCreation/MakeAvatarModal';
@@ -10,6 +10,7 @@ import GetStarted from '../SignupProcess/GetStarted';
 import { ThemeIcon, ThemeImage } from '../ThemeIcon';
 //import passwordValidator from 'password-validator';
 import { createNewUser, getCurrentUsername, getUserByEmail } from '../../api/users';
+import { ThemeContext } from '../../contexts/ThemeContext';
 
 /**
  * Sign up page. Records user input, validates user-given information with server data, and records it to server if valid.
@@ -47,6 +48,7 @@ const SignUp = ({ /*setAvatarImage, avatarImage,*/ profileImage, setProfileImage
   // const [selectedInterests, setSelectedInterests] = useState<string[]>([]); // State variable for the selected interests
   const [pronouns, setPronouns] = useState(''); // State variable for the user's pronouns
   const [bio, setBio] = useState(''); // State variable for the user's bio
+  const { theme } = useContext(ThemeContext); //The theme value from ThemeContext.
 
   // user info to be sent to the backend
   //we don't need name stuff, your email handles that
@@ -84,10 +86,26 @@ const SignUp = ({ /*setAvatarImage, avatarImage,*/ profileImage, setProfileImage
       callback: handleGoogle,
     });
 
+    //Sets the string for the Google Sign Up button.
+    let googleBtnTheme = new String("");
+
+    //If we're in dark mode, we use filled_black.
+    if(theme == 'dark'){
+      googleBtnTheme = "filled_black";
+    }
+    //Light mode uses outline.
+    else if(theme == 'light'){
+      googleBtnTheme = "outline";
+    }
+    //The filled_blue option shows up in case something goes wrong.
+    else{
+      googleBtnTheme = "filled_blue";
+    }
+
     // @ts-expect-error google
     google.accounts.id.renderButton(
       document.getElementById("googleBtn"),
-      { theme: "filled_black", size: "large" , shape: 'pill'}
+      { theme: googleBtnTheme, size: "large" , shape: 'pill', text: "signup_with"}
     );
   async function handleGoogle(response: any){
     setGoogleCredentials(response.credential)


### PR DESCRIPTION
Changes both the login and signup pages. The visual of the button changes depending on whether it's light mode or dark mode.

Did you know that these buttons are injected using Google APIs and thus our CSS style rules don't directly work on them? That's a pain.