### PR TITLE
Profile editor - reordering skills

### DIFF
--- a/client/src/components/Profile/tabs/SkillsTab.tsx
+++ b/client/src/components/Profile/tabs/SkillsTab.tsx
@@ -3,13 +3,16 @@
   Currently, this tab does not work
   Feel free to replace this entire file, or try and debug the code
   */
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, Fragment } from "react";
 import { SearchBar } from "../../SearchBar";
 import { getSkills } from "../../../api/users";
 import { Tag } from "../../Tag";
-import { MySkill, Skill } from "@looking-for-group/shared";
+import { MySkill, Skill, MePrivate, TagType } from "@looking-for-group/shared";
 import { userDataManager } from "../../../api/data-managers/user-data-manager";
 import { PendingUserProfile } from "../../../../types/types";
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from "@dnd-kit/core";
+import { SortableContext, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { SortableTag } from "../../ProjectCreatorEditor/tabs/SortableItem";
 
 const skillTabs = ["Developer Skills", "Design Skills", "Soft Skills", "Audio Skills"];
 
@@ -90,6 +93,54 @@ export const SkillsTab = ({
     return "unselected";
   }
 
+  // Drag-and-drop sensors for the sortable selected-tags list.
+  // Pointer for mouse/touch, Keyboard for accessible reordering.
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  /**
+     * Reorders the selected tags when a drag finishes.
+     * Note: tag order is only kept for this edit session — the backend has no
+     * tag-position column, so the order resets to the server's order on reload.
+     * @param e Drag end event with the active (dragged) and over (target) tag ids.
+     */
+    const handleDragEnd = (e: DragEndEvent) => {
+      const { active, over } = e;
+      if (!over || active.id === over.id) return;
+  
+      const skills = profile.skills;
+      const oldIndex = skills.findIndex((s) => s.skillId === Number(active.id));
+      const newIndex = skills.findIndex((s) => s.skillId === Number(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+  
+      const reorderedSkills = arrayMove([...skills], oldIndex, newIndex).map(
+        (skill, index) => ({
+          ...skill,
+          position: index,
+        })
+      );
+
+      const updatedProfile = {
+        ...profile,
+        skills: reorderedSkills,
+      };
+
+      dataManager.updateSkill({
+        id: {
+          type: "canon",
+          value: reorderedSkills[newIndex].skillId,
+        },
+        data: {
+          position: reorderedSkills[newIndex].position,
+        },
+      });
+
+      updatePendingProfile(updatedProfile);
+    };
 
   /**
    * Toggles a skill as selected or unselected
@@ -99,7 +150,7 @@ export const SkillsTab = ({
       const isSelected = isSkillSelected(skillId) === "selected";
 
       const skillToToggle = allSkills.find((potentialMatch) => potentialMatch.skillId === skillId);
-      
+
       if (!skillToToggle) return;
 
       if (isSelected) {
@@ -125,7 +176,7 @@ export const SkillsTab = ({
           },
           data: {
             skillId,
-            position: 0,
+            position: profile.skills.length, // add to end of list by default
             proficiency: "Novice", // TODO add proficiency
           },
         });
@@ -138,7 +189,7 @@ export const SkillsTab = ({
               ...skillToToggle,
               apiUrl: "",
               proficiency: "Novice",
-              position: 0,
+              position: profile.skills.length, // add to end of list by default
             },
           ],
         });
@@ -147,27 +198,7 @@ export const SkillsTab = ({
     [allSkills, dataManager, isSkillSelected, profile, updatePendingProfile]
   );
 
-  /**
-   * Renders selected profile skills.
-   * @returns JSX Element
-   */
-  const loadProfileSkills = useMemo(() => {
-    if (!profile?.skills) return [];
-
-    console.log(profile.skills);
-
-    return profile.skills.map((skill) => (
-      <Tag
-        key={skill.label}
-        onClick={() => handleSkillToggle(skill.skillId)}
-        type={skill.type.toLowerCase() + " skill"}
-        selected={true}
-      >
-        <i className="fa fa-close"></i>
-        <p>&nbsp;{skill.label}</p>
-      </Tag>
-    ));
-  }, [profile.skills]);
+  const selectedSkills = profile.skills.sort((a, b) => a.position - b.position) || [];
 
   /**
    * Renders skill tags as clickable buttons based on the active tab and search results.
@@ -305,15 +336,15 @@ export const SkillsTab = ({
   };
 
   const originalSkillOrder = useMemo(() => {
-    return (unmodifiedProfile.skills || []).map(s => s.skillId);
-  }, []);
+    return (unmodifiedProfile.skills || []).map((s: MySkill) => s.skillId);
+  }, [unmodifiedProfile.skills]);
 
   // Does Skills match in EXACT order
   const isSkillsUnsaved = useMemo(() => {
     const currentskills = profile.skills || [];
-    
+
     if (currentskills.length !== originalSkillOrder.length) return true;
-    
+
     // Checks if any element shifted index or changed
     return currentskills.some((s, index) => s.skillId !== originalSkillOrder[index]);
   }, [profile.skills, originalSkillOrder]);
@@ -328,15 +359,37 @@ export const SkillsTab = ({
             <span className="unsaved-indicator">
               (Unsaved)
             </span>
-          )}  
+          )}
         </div>
         <div className="project-editor-extra-info">
           Drag and drop to reorder
         </div>
-        <div id="project-editor-selected-tags-container">
-          {/* TODO: Separate top 2 skills from others with hr element, see Project editor links tab for implementation */}
-          {loadProfileSkills}
-        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={selectedSkills.map((t) => t.skillId)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div id="project-editor-selected-tags-container">
+              {selectedSkills.map((skill) => (
+                <Fragment key={skill.skillId}>
+                  <SortableTag
+                    id={skill.skillId}
+                    tag={{
+                      tagId: skill.skillId,
+                      label: skill.label,
+                      type: skill.type as TagType,
+                    }}
+                    onRemove={handleSkillToggle}
+                  />
+                </Fragment>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       </div>
 
       <div id="project-editor-tag-search">

--- a/client/src/components/ProjectCreatorEditor/tabs/SortableItem.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/SortableItem.tsx
@@ -45,7 +45,13 @@ export const SortableTag = ({
       </button>
       <TagElement
         selected={true}
-        type={tag.type.toLowerCase()}
+        type={
+          ["developer", "designer", "soft", "audio"].includes(
+            tag.type.toLowerCase()
+          )
+            ? `${tag.type.toLowerCase()} skill`
+            : tag.type.toLowerCase()
+        }
         onClick={() => onRemove(tag.tagId)}
       >
         <i className="fa fa-close"></i>

--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -366,7 +366,7 @@ const Profile = () => {
                 {displayedProfile?.skills !== undefined && (
                   /* Will take in a list of tags the user has selected, then */
                   /* use a map function to generate tags to fill this div */
-                  displayedProfile?.skills.map((tag) => {
+                  displayedProfile?.skills.sort((a, b) => a.position - b.position).map((tag) => {
                     let category: string;
                     switch (tag.type) {
                       case "Designer":

--- a/server/src/services/me/skills/delete-skills.ts
+++ b/server/src/services/me/skills/delete-skills.ts
@@ -1,5 +1,6 @@
 import prisma from '#config/prisma.ts';
 import type { ServiceErrorSubset, ServiceSuccessSusbet } from '#services/service-outcomes.ts';
+import { getSkillsService } from './get-skills.ts';
 
 type DeleteSkillServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND'>;
 type DeleteSkillServiceSuccess = ServiceSuccessSusbet<'NO_CONTENT'>;
@@ -18,6 +19,29 @@ export const deleteSkillService = async (
         },
       },
     });
+
+    const skills = await getSkillsService(userId);
+
+    if (skills === 'INTERNAL_ERROR' || skills === 'NOT_FOUND') {
+      return skills;
+    }
+
+    for (let i = 0; i < skills.length; i++) {
+      const currentSkill = skills[i];
+      if (currentSkill.position !== i) {
+        await prisma.userSkills.update({
+          where: {
+            userId_skillId: {
+              userId,
+              skillId: currentSkill.skillId,
+            },
+          },
+          data: {
+            position: i,
+          },
+        });
+      }
+    }
 
     return 'NO_CONTENT';
   } catch (error) {

--- a/server/src/services/me/skills/update-skills.ts
+++ b/server/src/services/me/skills/update-skills.ts
@@ -3,6 +3,7 @@ import prisma from '#config/prisma.ts';
 import { MySkillSelector } from '#services/selectors/me/parts/my-skill.ts';
 import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
 import { transformMySkill } from '#services/transformers/me/parts/my-skill.ts';
+import { getSkillsService } from './get-skills.ts';
 
 type UpdateSkillsServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND' | 'CONFLICT'>;
 
@@ -13,7 +14,25 @@ const updateSkillsService = async (
   data: UpdateUserSkillInput,
 ): Promise<MySkill | UpdateSkillsServiceError> => {
   try {
-    //this is just for proficiency for now
+    const skills = await getSkillsService(userId);
+
+    if (skills === 'INTERNAL_ERROR' || skills === 'NOT_FOUND') {
+      return skills;
+    }
+
+    const oldIndex = skills.findIndex((s) => s.skillId === skillId);
+    if (oldIndex === -1) {
+      return 'NOT_FOUND';
+    }
+
+    const [movedSkill] = skills.splice(oldIndex, 1);
+
+    // insert at new position
+    const targetIndex = data.position !== undefined ? data.position : oldIndex;
+
+    skills.splice(targetIndex, 0, movedSkill);
+
+    // update the moved skill with new proficiency and position
     const result = await prisma.userSkills.update({
       where: {
         userId_skillId: {
@@ -23,10 +42,29 @@ const updateSkillsService = async (
       },
       data: {
         ...(data.proficiency !== undefined && { proficiency: data.proficiency }), //this is currently defaulting to novice, but it can handle different changes to it
-        ...(data.position !== undefined && { position: data.position }), //maybe it will find use someday
+        ...(data.position !== undefined && { position: data.position }),
       },
       select: MySkillSelector,
     });
+
+    // renumber all skills
+    for (const [index, s] of skills.entries()) {
+      if (s.position !== index) {
+        // update display order in db if it doesn't match the new order
+        s.position = index;
+        await prisma.userSkills.update({
+          where: {
+            userId_skillId: {
+              userId,
+              skillId: s.skillId,
+            },
+          },
+          data: {
+            position: index,
+          },
+        });
+      }
+    }
 
     return transformMySkill(result);
   } catch (e) {

--- a/server/tests/metest/delete-user.test.ts
+++ b/server/tests/metest/delete-user.test.ts
@@ -22,6 +22,7 @@ vi.mock('#config/prisma.ts', () => ({
       deleteMany: vi.fn(),
     },
     users: {
+      findFirst: vi.fn(),
       delete: vi.fn(),
     },
   },
@@ -33,6 +34,7 @@ describe('deleteUserService', () => {
   });
 
   it('returns NOT_FOUND if user does not exist', async () => {
+    vi.mocked(prisma.users.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.users.delete).mockRejectedValue(new Error('User not found'));
 
     const result = await deleteUserService(1);
@@ -41,7 +43,7 @@ describe('deleteUserService', () => {
   });
 
   it('deletes user and related data successfully', async () => {
-    vi.mocked(prisma.userSocials.findFirst).mockResolvedValue({ userId: 1 } as any);
+    vi.mocked(prisma.users.findFirst).mockResolvedValue({ userId: 1 } as any);
     vi.mocked(prisma.userFollowings.deleteMany).mockResolvedValue({ count: 1 });
     vi.mocked(prisma.userSkills.deleteMany).mockResolvedValue({ count: 1 });
     vi.mocked(prisma.userSocials.deleteMany).mockResolvedValue({ count: 1 });
@@ -61,7 +63,7 @@ describe('deleteUserService', () => {
   });
 
   it('returns INTERNAL_ERROR on exception', async () => {
-    vi.mocked(prisma.userSocials.findFirst).mockResolvedValue({ userId: 1 } as any);
+    vi.mocked(prisma.users.findFirst).mockResolvedValue({ userId: 1 } as any);
     vi.mocked(prisma.users.delete).mockRejectedValue(new Error('db exploded :fire:'));
 
     const result = await deleteUserService(1);

--- a/server/tests/metest/followings/add-follow-proj.test.ts
+++ b/server/tests/metest/followings/add-follow-proj.test.ts
@@ -2,7 +2,7 @@ import type {
   MyProjectFollowing,
   ProjectMedium,
   ProjectPreview,
-  Tag,
+  ProjectTag,
   UserPreview,
 } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -54,8 +54,10 @@ const transformedProjectPreview: ProjectPreview = {
       label: '',
       tagId: 1,
       type: 'Creative',
+      apiUrl: 'api/projects/tags/1',
+      displayOrder: 0,
     },
-  ] as Tag[],
+  ] as ProjectTag[],
   thumbnail: null,
   thumbnailId: 0,
   title: '',

--- a/server/tests/metest/skills/delete-skills.test.ts
+++ b/server/tests/metest/skills/delete-skills.test.ts
@@ -1,16 +1,26 @@
-import type { SkillProficiency } from '@looking-for-group/shared';
+import type { SkillProficiency, SkillType } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import { deleteSkillService } from '#services/me/skills/delete-skills.ts';
+import { getSkillsService } from '#services/me/skills/get-skills.ts';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
 vi.mock('#config/prisma.ts', () => ({
   default: {
+    skills: {
+      findMany: vi.fn(),
+    },
     userSkills: {
       delete: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
     },
   },
+}));
+
+vi.mock('#services/me/skills/get-skills.ts', () => ({
+  getSkillsService: vi.fn(),
 }));
 
 const prismaUserSkill = {
@@ -20,6 +30,15 @@ const prismaUserSkill = {
   proficiency: 'Novice' as SkillProficiency,
 };
 
+const skills = [
+  {
+    ...prismaUserSkill,
+    apiUrl: '',
+    label: 'JavaScript',
+    type: 'Developer' as SkillType,
+  },
+];
+
 describe('deleteSkillService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,6 +46,8 @@ describe('deleteSkillService', () => {
 
   it('returns NO_CONTENT after user skill is deleted', async () => {
     vi.mocked(prisma.userSkills.delete).mockResolvedValue(prismaUserSkill);
+    vi.mocked(getSkillsService).mockResolvedValue(skills);
+    vi.mocked(prisma.userSkills.update).mockResolvedValue(prismaUserSkill);
 
     const result = await deleteSkillService(1, 1);
 

--- a/server/tests/metest/skills/update-skills.test.ts
+++ b/server/tests/metest/skills/update-skills.test.ts
@@ -1,6 +1,7 @@
 import type { MySkill, SkillType, SkillProficiency } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
+import { getSkillsService } from '#services/me/skills/get-skills.ts';
 import updateSkillsService from '#services/me/skills/update-skills.ts';
 import { transformMySkill } from '#services/transformers/me/parts/my-skill.ts';
 
@@ -20,6 +21,10 @@ vi.mock('#services/transformers/me/parts/my-skill.ts', () => ({
   transformMySkill: vi.fn(),
 }));
 
+vi.mock('#services/me/skills/get-skills.ts', () => ({
+  getSkillsService: vi.fn(),
+}));
+
 const prismaUserSkills = {
   proficiency: 'Novice' as SkillProficiency,
   position: 1,
@@ -29,6 +34,17 @@ const prismaUserSkills = {
     type: 'Designer' as SkillType,
   },
 };
+
+const skills = [
+  {
+    apiUrl: '',
+    proficiency: 'Novice' as SkillProficiency,
+    position: 1,
+    skillId: 1,
+    label: '',
+    type: 'Designer' as SkillType,
+  },
+];
 
 const transformed: MySkill = {
   apiUrl: 'api/me/skills',
@@ -45,6 +61,7 @@ describe('updateSkillsService', () => {
   });
 
   it('returns transformed my skills', async () => {
+    vi.mocked(getSkillsService).mockResolvedValue(skills);
     vi.mocked(prisma.userSkills.update).mockResolvedValue(prismaUserSkills as any);
     vi.mocked(transformMySkill).mockReturnValue(transformed);
 
@@ -56,7 +73,19 @@ describe('updateSkillsService', () => {
     expect(result).toBe(transformed);
   });
 
+  it('returns NOT_FOUND if user has no skills', async () => {
+    vi.mocked(getSkillsService).mockResolvedValue('NOT_FOUND');
+
+    const result = await updateSkillsService(1, 1, {
+      position: 2,
+      proficiency: 'Advanced' as SkillProficiency,
+    });
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
   it('returns NOT_FOUND if skill does not exist', async () => {
+    vi.mocked(getSkillsService).mockResolvedValue(skills);
     vi.mocked(prisma.userSkills.update).mockRejectedValue({ code: 'P2025' } as any);
 
     const result = await updateSkillsService(1, 1, {
@@ -79,7 +108,7 @@ describe('updateSkillsService', () => {
   });
 
   it('returns INTERNAL_ERROR when prisma throws', async () => {
-    vi.mocked(prisma.userSkills.update).mockRejectedValue(new Error('db cursed'));
+    vi.mocked(getSkillsService).mockRejectedValue(new Error('db cursed'));
 
     const result = await updateSkillsService(1, 1, {
       position: 2,


### PR DESCRIPTION
#876 
Updated the skills tab under profile editor so users can drag and drop skill tags to reorder them.
Updated the skills related services to store the position of skills.
Updated the skills related unit tests to match the current implementation.