### PR TITLE
Brady focus outline fix

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,3 +10,18 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+#profile-btn svg,
+#profile-btn svg:focus,
+#profile-btn svg:active,
+#profile:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+button svg,
+button svg:focus,
+svg[tabindex="-1"]:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION
Focus outlines in button should now be completely gone. Added an extra rule to the css to specify SVGs inside of buttons should never have focus outlines.