### PR TITLE
fixed multiple failed calls to api/me

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -10,6 +10,7 @@ import profilePicture from '../images/blue_frog.png';
 
 //user utils
 import { getCurrentAccount, getCurrentUsername, googleLogout } from '../api/users.ts';
+import { MePrivate } from '@looking-for-group/shared';
 
 //Header component to be used in pages
 
@@ -26,6 +27,7 @@ type HeaderProps = {
   value? : string;
   onChange? : (e: ChangeEvent<HTMLInputElement>) => void;
   hideSearchBar? : boolean;
+  setCurrentUserId?: (data: MePrivate | undefined) => Promise<void>;
 };
 
 /**
@@ -43,7 +45,7 @@ type HeaderProps = {
  * @returns A fully featured header containing the search bar, 
  * user dropdown menu, theme toggle, and navigation controls.
  */
-export const Header : React.FC<HeaderProps> = ({ dataSets, onSearch, value = "", onChange, hideSearchBar = false }) => {
+export const Header : React.FC<HeaderProps> = ({ dataSets, onSearch, value = "", onChange, hideSearchBar = false, setCurrentUserId}) => {
   // User info state
   const [username, setUsername] = useState<string | null>(null);
   const [email, setEmail] = useState('');
@@ -64,17 +66,20 @@ export const Header : React.FC<HeaderProps> = ({ dataSets, onSearch, value = "",
   useEffect(() => {
     const fetchUsername = async () => {
       try {
+        if(userId === -1) return;
         const res = await getCurrentAccount();
 
         if (res.status == 200 && res.data?.username) {
           loggedIn = true;
           setUsername(res.data.username);
           setUserId(res.data.userId);
+          if (setCurrentUserId) setCurrentUserId(res.data);
           setEmail(res.data.ritEmail);
           setProfileImg(res.data.profileImage ?? profilePicture);
         } else {
           loggedIn = false;
-          setUserId(undefined);
+          setUserId(-1);
+          if (setCurrentUserId) setCurrentUserId(undefined);
           setUsername('Guest');
           setEmail('');
           setProfileImg('');
@@ -82,7 +87,8 @@ export const Header : React.FC<HeaderProps> = ({ dataSets, onSearch, value = "",
       } catch (err) {
         console.log('Error fetching username: ' + err);
         loggedIn = false;
-        setUserId(undefined);
+        setUserId(-1);
+          if (setCurrentUserId) setCurrentUserId(undefined);
         setUsername('Guest');
         setEmail('');
         setProfileImg('');

--- a/client/src/components/PanelBox.tsx
+++ b/client/src/components/PanelBox.tsx
@@ -16,7 +16,7 @@ import { ProjectWithFollowers, UserPreview, NumberDictionary, StructuredProjectI
  * @param itemAddInterval - Number of items to add to the display when scrolling.
  * @returns The rendered panel box containing the items.
  */
-export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache, followedProjectIds }: { category: string, itemList: unknown[], itemAddInterval: number, projectCache?: NumberDictionary<StructuredProjectInfo>, followedProjectIds?: Set<number> }) => {
+export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache, followedProjectIds, userId }: { category: string, itemList: unknown[], itemAddInterval: number, projectCache?: NumberDictionary<StructuredProjectInfo>, followedProjectIds?: Set<number>, userId: number, }) => {
   // Don't display all items at first, load them in periodically
   // Currently rendered subset of items. Initially displays only a portion (controlled by itemAddInterval).
   const [displayedItems, setDisplayedItems] = useState(itemList.slice(0, itemAddInterval));
@@ -75,6 +75,7 @@ export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache
                 project={project}
                 initialIsFollowing={followedProjectIds?.has(projectId)}
                 key={projectId}
+                currentUserId={userId}
               />
             );
           })
@@ -99,7 +100,7 @@ export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache
       >
         {displayedItems.length > 0 ? (
           displayedItems.map((profile) => (
-            <ProfilePanel profileData={profile as UserPreview} key={(profile as UserPreview).userId} />
+            <ProfilePanel profileData={profile as UserPreview} currentUserId={userId} key={(profile as UserPreview).userId} />
           ))
         ) : (
           <>Sorry, no people here</>

--- a/client/src/components/ProfilePanel.tsx
+++ b/client/src/components/ProfilePanel.tsx
@@ -9,6 +9,7 @@ import { addUserFollowing, deleteUserFollowing, getCurrentAccount, getUsersById 
 
 interface ProfilePanelProps {
   profileData: UserPreview;
+  currentUserId: number;
 }
 
 /**
@@ -20,7 +21,7 @@ interface ProfilePanelProps {
  * @param profileData - UserPreview object containing basic user info (name, image, title, location, pronouns, fun fact, etc.)
  * @returns JSX element representing a user profile panel
  */
-export const ProfilePanel = ({ profileData }: ProfilePanelProps) => {
+export const ProfilePanel = ({ profileData, currentUserId }: ProfilePanelProps) => {
 
   const navigate = useNavigate();
   const profileURL = `${paths.routes.PROFILE}?userID=${profileData.userId}`;
@@ -29,7 +30,7 @@ export const ProfilePanel = ({ profileData }: ProfilePanelProps) => {
   
   //follow stuff
   // Current logged-in user id
-  const [userId, setUserId] = useState<number>();
+  const [userId, setUserId] = useState<number>(currentUserId);
   // Whether the current user follows the displayed user
   const [isFollow, setIsFollow] = useState<boolean>(false);
   /**
@@ -44,8 +45,10 @@ export const ProfilePanel = ({ profileData }: ProfilePanelProps) => {
     useEffect(() => {
       const getFollowData = async () => {
         //get our current user so we can check their follow status
-        const userResp = await getCurrentAccount();
-        if(userResp.data) setUserId(userResp.data.userId);
+        if (userId !== -1) {
+          const userResp = await getCurrentAccount();
+          if(userResp.data) setUserId(userResp.data.userId);
+        }
         
         //get the displayed user (again...) so we have their followers
         //because followers are currently not in the profileData
@@ -69,7 +72,7 @@ export const ProfilePanel = ({ profileData }: ProfilePanelProps) => {
      * Toggles following the user.
      */
     const toggleFollow = async () => {
-      if (!userId) {
+      if (userId !== -1) {
         navigate(paths.routes.LOGIN, { state: { from: location.pathname } }); // Redirect if logged out
       } else {
         // otherwise, toggle follow state

--- a/client/src/components/ProjectPanel.tsx
+++ b/client/src/components/ProjectPanel.tsx
@@ -7,7 +7,7 @@ import { Tag as TagElement } from './Tag';
 
 //import shares types
 import usePreloadedImage from '../functions/imageLoad.tsx';
-import { ProjectWithFollowers, ProjectMedium, Tag } from '@looking-for-group/shared';
+import { ProjectWithFollowers, ProjectMedium } from '@looking-for-group/shared';
 import React from 'react';
 import { getByID } from '../api/projects.ts';
 import { ThemeIcon } from './ThemeIcon.tsx';
@@ -19,6 +19,7 @@ import { ThemeIcon } from './ThemeIcon.tsx';
 interface ProjectPanelProps {
   project: ProjectWithFollowers;
   initialIsFollowing?: boolean;
+  currentUserId: number;
 }
 
 /**
@@ -29,12 +30,12 @@ interface ProjectPanelProps {
  * @param project - ProjectWithFollowers object containing project info, thumbnail, tags, and follower data
  * @returns JSX element rendering a clickable project preview panel with follow functionality
  */
-export const ProjectPanel = ({ project, initialIsFollowing }: ProjectPanelProps) => {
+export const ProjectPanel = ({ project, initialIsFollowing, currentUserId }: ProjectPanelProps) => {
   const navigate = useNavigate();
   const projectURL = `${paths.routes.PROJECT}?projectID=${project.projectId}`;
 
   // Current user ID (for follow logic)
-  const [userId, setUserId] = useState<number>();
+  const [userId, setUserId] = useState<number>(currentUserId);
   // Local state for follow count and current user's follow status
   const [followCount, setFollowCount] = useState(project.followers?.count ?? 0);
   const [isFollowing, setFollowing] = useState(initialIsFollowing ?? false);
@@ -72,7 +73,7 @@ export const ProjectPanel = ({ project, initialIsFollowing }: ProjectPanelProps)
    * @returns boolean indicating follow status
    */
   const checkFollow = useCallback(async () => {
-    if (userId) {
+    if (userId !== -1 && userId) {
       const followings = (await getProjectFollowing(userId)).data?.projects;
 
       let isFollow = false;
@@ -93,8 +94,10 @@ export const ProjectPanel = ({ project, initialIsFollowing }: ProjectPanelProps)
   useEffect(() => {
     const getProjectData = async () => {
       //get our current user for use later
-      const userResp = await getCurrentAccount();
-      if (userResp.data) setUserId(userResp.data.userId);
+      if (!userId && userId !== -1) {
+        const userResp = await getCurrentAccount();
+        if (userResp.data) setUserId(userResp.data.userId);
+      }
 
       // Check if we already have full project data with followers
       // If not, fetch it to get the current follower count
@@ -128,7 +131,7 @@ export const ProjectPanel = ({ project, initialIsFollowing }: ProjectPanelProps)
   const handleFollowClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
 
-    if (!userId || userId === 0) {
+    if (!userId || userId === -1) {
       navigate(paths.routes.LOGIN);
       return;
     }

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -187,8 +187,9 @@ const SideBar = () => {
   const handleProfileAccess = async () => {
     // navigate to Profile, attach userID
     const res = await getCurrentUsername();
-    const userId = res.data.userId;
-    navigate(`${paths.routes.PROFILE}?userID=${userId}`);
+    const userId = res.data?.userId;
+    if (userId) navigate(`${paths.routes.PROFILE}?userID=${userId}`);
+    else navigate(paths.routes.LOGIN);
 
     // Collapse the dropwdown if coming from another user's page
     if (window.location.href.includes("profile")) {

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -7,10 +7,11 @@ import { PanelBox } from '../PanelBox';
 import { ThemeImage } from '../ThemeIcon';
 import ToTopButton from '../ToTopButton';
 import { getProjects, getByID } from '../../api/projects';
-import { getUsers, getUsersById, getCurrentAccount, getProjectFollowing } from '../../api/users';
+import { getUsers, getUsersById, getProjectFollowing } from '../../api/users';
 import { ApiResponse, Tag, NumberDictionary, StructuredProjectInfo,
     StructuredUserInfo, UserPreview, ProjectPreview, 
-    UserDetail, ProjectWithFollowers } from '@looking-for-group/shared';
+    UserDetail, ProjectWithFollowers, 
+    MePrivate} from '@looking-for-group/shared';
 
 //import api utils
 // Current auth and follow state are loaded with getCurrentAccount/getProjectFollowing
@@ -134,6 +135,11 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
   // --------------------
 
   const loadFollowedProjectIds = async (userId: number) => {
+    if (currentUserId === -1) {
+      setFollowedProjectIds(new Set());
+      return;
+    }
+
     try {
       const response = await getProjectFollowing(userId);
       if (response.data?.projects) {
@@ -148,17 +154,13 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
   /**
    * Loads the current user and their followed projects so follow icons render immediately.
    */
-  const getAuth = async () => {
-    if (currentUserId !== null) {
-      return;
-    }
+  const getAuth = async (data: MePrivate | undefined) => {
 
-    const res = await getCurrentAccount();
-    if (res.status === 200 && res.data?.userId) {
-      setCurrentUserId(res.data.userId);
-      await loadFollowedProjectIds(res.data.userId);
+    if (data) {
+      setCurrentUserId(data.userId);
+      await loadFollowedProjectIds(data.userId);
     } else {
-      setCurrentUserId(null);
+      setCurrentUserId(-1);
       setFollowedProjectIds(new Set());
     }
   };
@@ -183,7 +185,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     // Pre-fetch full details for the first visible batch to avoid flashing like/count state
     const INITIAL_LOAD_COUNT = 25;
     for (let i = 0; i < Math.min(INITIAL_LOAD_COUNT, projects.data.length); i++) {
-      const projectPreview = projects.data[i];
+      const projectPreview = projects.data[i] as ProjectPreview;
       const projectId = projectPreview.projectId;
       if (!newProjectCache[projectId]?.full) {
         try {
@@ -243,7 +245,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
       if (fetchedProjects && fetchedUsers && !force) return;
 
       // Get user profile
-      await getAuth();
+      //await getAuth();
 
       try {
         if(category == 'projects') {
@@ -594,6 +596,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
           itemAddInterval={25}
           projectCache={projectCache}
           followedProjectIds={followedProjectIds}
+          userId={currentUserId ?? -1}
         />
       );
     }
@@ -606,7 +609,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
       );
     }
     else {
-      discoverPanelContents = (<PanelBox category={category} itemList={filteredUserList} itemAddInterval={25} />);
+      discoverPanelContents = (<PanelBox category={category} itemList={filteredUserList} itemAddInterval={25} userId={currentUserId ?? -1}/>);
     }
   }
 
@@ -616,7 +619,8 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
       {/* Search bar and profile/notification buttons */}
       <Header dataSets={ category == 'projects' ? projectDataSet : userDataSet }
           onSearch={ category == 'projects' ? searchProjects : searchUsers }
-          value={currentSearch} onChange={(e : ChangeEvent<HTMLInputElement>) => setCurrentSearch(e.currentTarget.value)} />
+          value={currentSearch} onChange={(e : ChangeEvent<HTMLInputElement>) => setCurrentSearch(e.currentTarget.value)} 
+          setCurrentUserId={getAuth}/>
       {/* Contains the hero display, carousel if projects, profile intro if profiles*/}
       {heroContent}
 

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -1,5 +1,5 @@
 // import { profiles } from "../../constants/fakeData";
-import { useState, useMemo, ChangeEvent, useEffect, useCallback } from 'react';
+import { useState, useMemo, ChangeEvent, useCallback } from 'react';
 // import { PagePopup, openClosePopup } from "../PagePopup";
 import ToTopButton from '../ToTopButton';
 import CreditsFooter from '../CreditsFooter';
@@ -14,7 +14,7 @@ import { ProjectCreatorEditor } from '../ProjectCreatorEditor/ProjectCreatorEdit
 
 //import api utils
 import { getCurrentUsername, getProjectsByUser } from '../../api/users.ts'
-import { ProjectDetail } from '@looking-for-group/shared';
+import { MePrivate, ProjectDetail } from '@looking-for-group/shared';
 
 /**
  * My Projects page. Creates a customizable page that showcases the user's projects.
@@ -66,28 +66,30 @@ const MyProjects = () => {
   const getUserProjects = async () => {
     try {
       const res = await getCurrentUsername();
-
-      // User is logged in, pull their data
-      if (res.data) {
-        setLoggedIn(res.data.userId);
-        const projectsRes = await getProjectsByUser();
-
-        if (projectsRes.data && projectsRes.data !== undefined) setProjectsList(projectsRes.data);
-
-        //console.log(projectsRes.data);
-        setUserId(res.data.username);
-        
-      } else {
-        //guest
-        setUserId("guest");
-        setLoggedIn(0);
-      }
+      setUserProjects({...res.data} as MePrivate)
 
     } catch (e) {
       console.error('error getting projects', e);
       setCreateError(true);
     }
+  }
 
+  const setUserProjects = async (data: MePrivate | undefined) => {
+    // User is logged in, pull their data
+    if (data) {
+      setLoggedIn(data.userId);
+      const projectsRes = await getProjectsByUser();
+
+      if (projectsRes.data && projectsRes.data !== undefined) setProjectsList(projectsRes.data);
+
+      //console.log(projectsRes.data);
+      setUserId(data.username);
+      
+    } else {
+      //guest
+      setUserId("guest");
+      setLoggedIn(0);
+    }
     setDataLoaded(true);
   }
 
@@ -127,9 +129,6 @@ const MyProjects = () => {
   // };
 
   // React likes this more than a boolean check
-  useEffect(() => {
-    getUserProjects();
-  }, []);
   // else {
   //     if (projectsList.length < 20) {
   //         let tempList = new Array(0);
@@ -412,6 +411,7 @@ const MyProjects = () => {
         onSearch={handleSearch}
         value={currentSearch}
         onChange={(e: ChangeEvent<HTMLInputElement>) => setCurrentSearch(e.currentTarget.value)}
+        setCurrentUserId={setUserProjects}
       />
 
       {/* Banner */}

--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -9,7 +9,7 @@ import "../Styles/projects.css";
 import "../Styles/settings.css";
 import "../Styles/pages.css";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import * as paths from "../../constants/routes";
 import { Header, loggedIn } from "../Header";
@@ -20,9 +20,9 @@ import { ThemeIcon } from "../ThemeIcon";
 import { ShareButton } from "../ShareButton";
 // import { ProfileInterests } from "../Profile/ProfileInterests";
 import profilePicture from "../../images/blue_frog.png";
-import { getVisibleProjects, getProjectsByUser, addUserFollowing, deleteUserFollowing, getCurrentAccount, getUserFollowing } from "../../api/users";
+import { getVisibleProjects, getProjectsByUser, addUserFollowing, deleteUserFollowing, getUserFollowing } from "../../api/users";
 import { getUsersById } from "../../api/users";
-import { MeDetail, ProjectPreview, UserDetail } from '@looking-for-group/shared';
+import { MeDetail, MePrivate, ProjectPreview, UserDetail } from '@looking-for-group/shared';
 import usePreloadedImage from "../../functions/imageLoad";
 
 type Profile = MeDetail;
@@ -76,7 +76,7 @@ const Profile = () => {
    * @returns true if following
    */
   const checkFollow = useCallback(async () => {
-    if (userID) {
+    if (userID !== -1 && userID !== undefined) {
       const followings = (await getUserFollowing(userID)).data?.users;
 
       let isFollowing = false;
@@ -162,33 +162,31 @@ const Profile = () => {
   }, [profileID, isUsersProfile, setFullProjectList, setDisplayedProjects]);
 
   // Gets the profile data
-  useEffect(() => {
-    const getProfileData = async () => {
-      // Get the userID for our current user
-      const response = await getCurrentAccount()
-      if (response.data) setUserID(response.data.userId);
-      if (userID) setIsUsersProfile(userID.toString() === profileID);
+  const getProfileData = async (data: MePrivate | undefined) => {
+    // Get the userID for our current user
+    if (data) setUserID(data.userId);
+    else setUserID(-1);
+    if (userID) setIsUsersProfile(userID.toString() === profileID);
 
-      try {
-        const { data } = await getUsersById(Number(profileID));
+    try {
+      const { data } = await getUsersById(Number(profileID));
 
-        // Only run this if profile data exists for user
-        if (data) {
-          setDisplayedProfile(data);
-          setMajorsArr(data.majors.map((maj) => maj.label));
-          await getProfileProjectData();
-          checkFollow();
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(error.message);
-        } else {
-          console.log(`Unknown error: ${error}`);
-        }
+      // Only run this if profile data exists for user
+      if (data) {
+        setDisplayedProfile(data);
+        setMajorsArr(data.majors.map((maj) => maj.label));
+        await getProfileProjectData();
+        checkFollow();
       }
-    };
-    getProfileData();
-  }, [getProfileProjectData, checkFollow, isUsersProfile, profileID, userID]);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      } else {
+        console.log(`Unknown error: ${error}`);
+      }
+    }
+  };
+    
 
   // --------------------
   // Components
@@ -286,6 +284,7 @@ const Profile = () => {
         onSearch={searchProjects}
         hideSearchBar={true}
         onChange={() => { }}
+        setCurrentUserId={getProfileData}
       />
 
       {/* Checks if we have profile data to use, then determines what to render */}
@@ -406,6 +405,7 @@ const Profile = () => {
                 category={"projects"}
                 itemList={displayedProjects}
                 itemAddInterval={25}
+                userId={userID as number}
               />
             ) : (
               <div>No projects to display</div>

--- a/client/src/components/pages/Project.tsx
+++ b/client/src/components/pages/Project.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header, loggedIn } from "../Header";
 import { Dropdown, DropdownButton, DropdownContent } from "../Dropdown";
@@ -13,7 +13,6 @@ import { ThemeIcon } from "../ThemeIcon";
 import { getByID } from "../../api/projects";
 import { Tag as TagElement } from "../Tag";
 import {
-  getCurrentAccount,
   deleteProjectFollowing,
   addProjectFollowing,
   getProjectFollowing,
@@ -71,35 +70,31 @@ const Project = () => {
   }, [projectID, userID]);
 
   // Sets state variables
-  useEffect(() => {
-    const getProjectData = async () => {
-      //get our current user for use later
-      const userResp = await getCurrentAccount();
-      if (userResp.data) {
-        setUser(userResp.data);
-        setUserID(userResp.data.userId);
-      }
+  const getProjectData = async (data: MePrivate | undefined) => {
+    //get our current user for use later
+    if (data) {
+      setUser(data);
+      setUserID(data.userId);
+    }
 
-      //get the project itself
-      const projectResp = await getByID(projectID);
-      if (projectResp.data) {
-        setDisplayedProject(projectResp.data);
-        checkFollow();
-        setFollowCount(projectResp.data.followers.count);
+    //get the project itself
+    const projectResp = await getByID(projectID);
+    if (projectResp.data) {
+      setDisplayedProject(projectResp.data);
+      checkFollow();
+      setFollowCount(projectResp.data.followers.count);
 
-        if (userResp.data) {
-          for (const member of projectResp.data.members) {
-            if (member.user.userId === userResp.data.userId) {
-              setIsMember(true);
-              return;
-            }
+      if (data) {
+        for (const member of projectResp.data.members) {
+          if (member.user.userId === data.userId) {
+            setIsMember(true);
+            return;
           }
         }
-
       }
-    };
-    getProjectData();
-  }, [projectID, checkFollow]);
+
+    }
+  };
 
   //Checks to see whether or not the current user is the maker/owner of the project being displayed
   //oh do i need this too
@@ -406,6 +401,7 @@ const Project = () => {
         hideSearchBar={true}
         value={undefined}
         onChange={undefined}
+        setCurrentUserId={getProjectData}
       />
 
       {displayedProject === undefined ? (


### PR DESCRIPTION
essentially took every single portion of the pages that need the user info, removed their individual attempts to get the current user, and had them all get the user info from a single get call in the header element. this leaves a single failed attempt every time you load a page, but I feel that's acceptable.
closes #1012 