### PR TITLE
project report backend endpoints

### DIFF
--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -874,6 +874,60 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/me/projects/report/{id}/{report}:
+    post:
+      summary: Report a project
+      security:
+        - shibbolethAuth: []
+      tags:
+        - Me
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the project to report
+          schema:
+            type: integer
+        - name: report
+          in: path
+          required: true
+          description: Report message
+          schema:
+            type: string
+        - in: query
+          name: devId
+          schema:
+            type: integer
+          required: false
+          description: The user ID to be used as the current user
+      responses:
+        '200':
+          description: Project reported successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  error:
+                    type: string
+                    nullable: true
+                    example: null
+                  data:
+                    type: object
+                    nullable: true
+                    example: null
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/me/socials:
     get:
       summary: Get current user's socials

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -3315,6 +3315,45 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/mod/project-report/:
+    get:
+      summary: Get a list of all project reports
+      tags:
+        - Mod
+      security:
+        - shibbolethAuth: []
+      parameters:
+        - in: query
+          name: devId
+          schema:
+            type: integer
+          required: false
+          description: The user ID to be used as the current user
+
+      responses:
+        '200':
+          description: Project reports acquired successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  error:
+                    type: string
+                    nullable: true
+                    example: null
+                  data:
+                    type: object
+                    nullabe: true
+                    example: null
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   # IMAGES
   /api/images/{image}:
     get:

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -3354,6 +3354,50 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/mod/project-report/{id}:
+    delete:
+      summary: Removes a project report
+      tags:
+        - Mod
+      security:
+        - shibbolethAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of report to delete
+          schema:
+            type: integer
+        - in: query
+          name: devId
+          schema:
+            type: integer
+          required: false
+          description: The user ID to be used as the current user
+      responses:
+        '200':
+          description: Project reports acquired successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  error:
+                    type: string
+                    nullable: true
+                    example: null
+                  data:
+                    type: object
+                    nullabe: true
+                    example: null
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   # IMAGES
   /api/images/{image}:
     get:

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -260,7 +260,6 @@ model Users {
   userSkills        UserSkills[]
   userSocials       UserSocials[]
   majors            Majors[]
-  userBlacklists    UserBlacklist[]
   report            ReportProject[]
 
   @@map("users")

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -143,6 +143,7 @@ model Projects {
   // tags              Tags[]
   users             Users               @relation(fields: [userId], references: [userId], map: "FK_user_id")
   tags              ProjectTags[]
+  report            ReportProject[]
 
   @@index([userId], map: "FK_user_id")
   @@map("projects")
@@ -260,6 +261,7 @@ model Users {
   userSocials       UserSocials[]
   majors            Majors[]
   userBlacklists    UserBlacklist[]
+  report            ReportProject[]
 
   @@map("users")
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -148,6 +148,20 @@ model Projects {
   @@map("projects")
 }
 
+model ReportProject {
+  reportId      Int       @id @default(autoincrement()) @map("report_id")
+  userId        Int       @map("user_id")
+  projectId     Int       @map("project_id")
+  reportText    String    @map("report_text")
+  users         Users     @relation(fields: [userId], references: [userId], map: "FK_project_report_users")
+  projects      Projects  @relation(fields: [projectId], references: [projectId], map: "FK_project_report_projects")
+
+  @@unique([userId, projectId])
+  @@index([userId], map: "FK_project_report_users")
+  @@index([projectId], map: "FK_project_report_projects")
+  @@map("report_project")
+}
+
 model Socials {
   websiteId      Int              @id @default(autoincrement()) @map("website_id")
   label          String           @unique @db.VarChar(50)

--- a/server/src/api/controllers/me/report-proj.ts
+++ b/server/src/api/controllers/me/report-proj.ts
@@ -1,0 +1,53 @@
+import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { Response } from 'express';
+import { reportProjectService } from '#services/me/report-proj.ts';
+
+/**
+ * PUT api/me/projects/reports/{id}/{report}
+ * Allows authenticated users to report a project
+ */
+const reportProjectController = async (req: AuthenticatedRequest, res: Response) => {
+  const projectId = parseInt(req.params.id);
+  const report = req.params.report;
+
+  const result = await reportProjectService(req.currentUser, projectId, report);
+
+  if (result === 'NOT_FOUND') {
+    const resBody: ApiResponse = {
+      status: 404,
+      error: 'Project not found',
+      data: null,
+    };
+    res.status(404).json(resBody);
+    return;
+  }
+
+  if (result === 'CONFLICT') {
+    const resBody: ApiResponse = {
+      status: 409,
+      error: 'Report already exists',
+      data: null,
+    };
+    res.status(409).json(resBody);
+    return;
+  }
+
+  if (result === 'INTERNAL_ERROR') {
+    const resBody: ApiResponse = {
+      status: 500,
+      error: 'Internal Server Error',
+      data: null,
+    };
+    res.status(500).json(resBody);
+    return;
+  }
+
+  const resBody: ApiResponse = {
+    status: 200,
+    error: null,
+    data: null,
+  };
+  res.status(200).json(resBody);
+};
+
+export { reportProjectController };

--- a/server/src/api/controllers/mod/delete-project-report.ts
+++ b/server/src/api/controllers/mod/delete-project-report.ts
@@ -1,0 +1,40 @@
+import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { Response } from 'express';
+import deleteProjectReportService from '#services/projects/delete-project-report.ts';
+
+//DELETE api/mod/project-report/{id}
+//deletes a project (moderator action)
+export const deleteProjectReport = async (
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> => {
+  const reportId = parseInt(req.params.id);
+
+  const result = await deleteProjectReportService(reportId);
+
+  if (result === 'NOT_FOUND') {
+    const resBody: ApiResponse = {
+      status: 404,
+      error: 'Report not found',
+      data: null,
+    };
+    res.status(404).json(resBody);
+    return;
+  }
+  if (result === 'INTERNAL_ERROR') {
+    const resBody: ApiResponse = {
+      status: 500,
+      error: 'Internal Server Error',
+      data: null,
+    };
+    res.status(500).json(resBody);
+    return;
+  }
+
+  const resBody: ApiResponse = {
+    status: 200,
+    error: null,
+    data: null,
+  };
+  res.status(200).json(resBody);
+};

--- a/server/src/api/controllers/mod/get-project-reports.ts
+++ b/server/src/api/controllers/mod/get-project-reports.ts
@@ -1,0 +1,38 @@
+import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { Response } from 'express';
+import getProjectReportService from '#services/projects/get-project-reports.ts';
+
+//GET api/mod/project-report/
+//removes user from blacklist
+export const getProjectReports = async (
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> => {
+  const result = await getProjectReportService();
+
+  if (result === 'NOT_FOUND') {
+    const resBody: ApiResponse = {
+      status: 404,
+      error: 'User not found',
+      data: null,
+    };
+    res.status(404).json(resBody);
+    return;
+  }
+  if (result === 'INTERNAL_ERROR') {
+    const resBody: ApiResponse = {
+      status: 500,
+      error: 'Internal Server Error',
+      data: null,
+    };
+    res.status(500).json(resBody);
+    return;
+  }
+
+  const resBody: ApiResponse = {
+    status: 200,
+    error: null,
+    data: result,
+  };
+  res.status(200).json(resBody);
+};

--- a/server/src/api/routes/me.ts
+++ b/server/src/api/routes/me.ts
@@ -13,6 +13,7 @@ import { leaveProjectController } from '#controllers/me/leave-project.ts';
 import addUserMajor from '#controllers/me/majors/add-major.ts';
 import { deleteMajor } from '#controllers/me/majors/delete-major.ts';
 import { getUserMajors } from '#controllers/me/majors/get-majors.ts';
+import { reportProjectController } from '#controllers/me/report-proj.ts';
 import addSkills from '#controllers/me/skills/add-skills.ts';
 import { deleteSkill } from '#controllers/me/skills/delete-skills.ts';
 import { getSkills } from '#controllers/me/skills/get-skills.ts';
@@ -103,6 +104,12 @@ router.put(
   projectExistsAt('path', 'id'),
   authenticated(userAttributeExistsAt('project', 'path', 'id')),
   authenticated(updateProjectVisibilityController),
+);
+//Report project
+router.post(
+  '/projects/report/:id/:report',
+  projectExistsAt('path', 'id'),
+  authenticated(reportProjectController),
 );
 
 // SKILLS ROUTES

--- a/server/src/api/routes/mod.ts
+++ b/server/src/api/routes/mod.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedRequest } from '@looking-for-group/shared';
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import { banUser } from '#controllers/mod/ban-user.ts';
 import { clearProfile } from '#controllers/mod/clear-profile.ts';
+import { deleteProjectReport } from '#controllers/mod/delete-project-report.ts';
 import { deleteProject } from '#controllers/mod/delete-project.ts';
 import { getProjectReports } from '#controllers/mod/get-project-reports.ts';
 import { unbanUser } from '#controllers/mod/unban-user.ts';
@@ -32,5 +33,5 @@ router.delete('/delete-project/:id/', authenticated(deleteProject));
 router.put('/ban-user/:googleId/', authenticated(banUser));
 router.delete('/unban-user/:googleId/', authenticated(unbanUser));
 router.get('/project-report/', authenticated(getProjectReports));
-
+router.delete('/project-report/:id', authenticated(deleteProjectReport));
 export default router;

--- a/server/src/api/routes/mod.ts
+++ b/server/src/api/routes/mod.ts
@@ -3,6 +3,7 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { banUser } from '#controllers/mod/ban-user.ts';
 import { clearProfile } from '#controllers/mod/clear-profile.ts';
 import { deleteProject } from '#controllers/mod/delete-project.ts';
+import { getProjectReports } from '#controllers/mod/get-project-reports.ts';
 import { unbanUser } from '#controllers/mod/unban-user.ts';
 import requiresLogin from '../middleware/authorization/requires-login.ts';
 import requiresModerator from '../middleware/authorization/requires-mod.ts';
@@ -30,5 +31,6 @@ router.patch('/clear-profile/:id/', authenticated(clearProfile));
 router.delete('/delete-project/:id/', authenticated(deleteProject));
 router.put('/ban-user/:googleId/', authenticated(banUser));
 router.delete('/unban-user/:googleId/', authenticated(unbanUser));
+router.get('/project-report/', authenticated(getProjectReports));
 
 export default router;

--- a/server/src/services/me/report-proj.ts
+++ b/server/src/services/me/report-proj.ts
@@ -4,7 +4,7 @@ import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service
 type GetServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'CONFLICT' | 'NOT_FOUND'>;
 type GetServiceSuccess = ServiceSuccessSubset<'OK'>;
 
-//PUT api/me/report-project/{id}
+//PUT api/me/projects/report/{id}/{report}
 export const reportProjectService = async (
   userId: number,
   projectId: number,
@@ -13,12 +13,12 @@ export const reportProjectService = async (
   try {
     //Check if project exists
     //Because this is being called by api/me, there is no need to validate the id of the user
-    const project = await prisma.reportProject.findFirst({
-      where: {
-        projectId,
-      },
-    });
-    if (!project) return 'NOT_FOUND';
+    // const project = await prisma.reportProject.findFirst({
+    //   where: {
+    //     projectId,
+    //   },
+    // });
+    // if (!project) return 'NOT_FOUND';
 
     //Check if report already exists
     const report = await prisma.reportProject.findFirst({

--- a/server/src/services/me/report-proj.ts
+++ b/server/src/services/me/report-proj.ts
@@ -11,15 +11,6 @@ export const reportProjectService = async (
   reportText: string,
 ): Promise<GetServiceSuccess | GetServiceError> => {
   try {
-    //Check if project exists
-    //Because this is being called by api/me, there is no need to validate the id of the user
-    // const project = await prisma.reportProject.findFirst({
-    //   where: {
-    //     projectId,
-    //   },
-    // });
-    // if (!project) return 'NOT_FOUND';
-
     //Check if report already exists
     const report = await prisma.reportProject.findFirst({
       where: {

--- a/server/src/services/me/report-proj.ts
+++ b/server/src/services/me/report-proj.ts
@@ -1,0 +1,47 @@
+import prisma from '#config/prisma.ts';
+import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service-outcomes.ts';
+
+type GetServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'CONFLICT' | 'NOT_FOUND'>;
+type GetServiceSuccess = ServiceSuccessSubset<'OK'>;
+
+//PUT api/me/report-project/{id}
+export const reportProjectService = async (
+  userId: number,
+  projectId: number,
+  reportText: string,
+): Promise<GetServiceSuccess | GetServiceError> => {
+  try {
+    //Check if project exists
+    //Because this is being called by api/me, there is no need to validate the id of the user
+    const project = await prisma.reportProject.findFirst({
+      where: {
+        projectId,
+      },
+    });
+    if (!project) return 'NOT_FOUND';
+
+    //Check if report already exists
+    const report = await prisma.reportProject.findFirst({
+      where: {
+        userId,
+        projectId,
+      },
+    });
+    if (report) return 'CONFLICT';
+
+    //Create report
+    await prisma.reportProject.create({
+      data: {
+        userId,
+        projectId,
+        reportText,
+      },
+    });
+
+    return 'OK';
+  } catch (e) {
+    console.error(`Error in reportProjectService: ${JSON.stringify(e)}`);
+
+    return 'INTERNAL_ERROR';
+  }
+};

--- a/server/src/services/projects/delete-project-report.ts
+++ b/server/src/services/projects/delete-project-report.ts
@@ -1,0 +1,34 @@
+import prisma from '#config/prisma.ts';
+import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service-outcomes.ts';
+
+type DeleteServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND'>;
+type DeleteServiceSuccess = ServiceSuccessSubset<'NO_CONTENT'>;
+
+//DELETE api/mod/project-report/{id}
+const deleteProjectReportService = async (
+  reportId: number,
+): Promise<DeleteServiceSuccess | DeleteServiceError> => {
+  try {
+    const report = await prisma.reportProject.findUnique({
+      where: {
+        reportId,
+      },
+    });
+
+    if (!report) return 'NOT_FOUND';
+
+    await prisma.reportProject.delete({
+      where: {
+        reportId,
+      },
+    });
+
+    return 'NO_CONTENT';
+  } catch (e) {
+    console.error(`Error in deleteProjectReportService: ${JSON.stringify(e)}`);
+
+    return 'INTERNAL_ERROR';
+  }
+};
+
+export default deleteProjectReportService;

--- a/server/src/services/projects/get-project-reports.ts
+++ b/server/src/services/projects/get-project-reports.ts
@@ -18,7 +18,7 @@ const getProjectReportsService = async (): Promise<ReportProject[] | GetServiceE
 
     return reports;
   } catch (e) {
-    console.error(`Error in getProjectsService: ${JSON.stringify(e)}`);
+    console.error(`Error in getProjectReportsService: ${JSON.stringify(e)}`);
 
     return 'INTERNAL_ERROR';
   }

--- a/server/src/services/projects/get-project-reports.ts
+++ b/server/src/services/projects/get-project-reports.ts
@@ -1,0 +1,27 @@
+import prisma from '#config/prisma.ts';
+import type { ReportProject } from '#prisma-models/index.js';
+import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
+
+type GetServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND'>;
+
+//GET api/mod/project-report
+const getProjectReportsService = async (): Promise<ReportProject[] | GetServiceError> => {
+  try {
+    const reports = await prisma.reportProject.findMany({
+      orderBy: {
+        //Ascending order of IDs means oldest first
+        reportId: 'asc',
+      },
+    });
+
+    if (reports.length === 0) return 'NOT_FOUND';
+
+    return reports;
+  } catch (e) {
+    console.error(`Error in getProjectsService: ${JSON.stringify(e)}`);
+
+    return 'INTERNAL_ERROR';
+  }
+};
+
+export default getProjectReportsService;

--- a/server/tests/projectstest/report-proj.test.ts
+++ b/server/tests/projectstest/report-proj.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import { reportProjectService } from '#services/me/report-proj.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    //I hate my stupid baka chungus life
+    reportProject: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    projectImages: {
+      findMany: vi.fn(),
+    },
+    roles: {
+      findMany: vi.fn(),
+    },
+    majors: {
+      findMany: vi.fn(),
+    },
+    users: {
+      findMany: vi.fn(),
+    },
+    jobs: {
+      findMany: vi.fn(),
+    },
+    members: {
+      findMany: vi.fn(),
+    },
+    socials: {
+      findMany: vi.fn(),
+    },
+    projectSocials: {
+      findMany: vi.fn(),
+    },
+    mediums: {
+      findMany: vi.fn(),
+    },
+    tags: {
+      findMany: vi.fn(),
+    },
+    projects: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const prismaReport = {
+  reportId: 3,
+  userId: 1,
+  projectId: 2,
+  reportText: 'test report',
+};
+
+describe('createProjectService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns OK when it creates a report', async () => {
+    vi.mocked(prisma.reportProject.findFirst).mockResolvedValue(null);
+
+    const result = await reportProjectService(1, 2, 'test report');
+
+    expect(prisma.reportProject.create).toHaveBeenCalledWith({
+      data: {
+        userId: 1,
+        projectId: 2,
+        reportText: 'test report',
+      },
+    });
+    expect(result).toEqual('OK');
+  });
+
+  it('returns CONFLICT if there already is report', async () => {
+    vi.mocked(prisma.reportProject.findFirst).mockResolvedValue(prismaReport);
+
+    const result = await reportProjectService(1, 2, 'test report');
+    expect(result).toEqual('CONFLICT');
+  });
+
+  it('returns INTERNAL_ERROR if prisma throws', async () => {
+    vi.mocked(prisma.reportProject.findFirst).mockRejectedValue(new Error('womp womp'));
+
+    const result = await reportProjectService(1, 2, 'test report');
+    expect(result).toEqual('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/report/delete-project-report.test.ts
+++ b/server/tests/projectstest/report/delete-project-report.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import deleteProjectReportService from '#services/projects/delete-project-report.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    reportProject: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+const prismaReport = {
+  reportId: 3,
+  userId: 1,
+  projectId: 2,
+  reportText: 'test report',
+};
+
+describe('deleteProjectReportService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns NO_CONTENT if successful', async () => {
+    vi.mocked(prisma.reportProject.findUnique).mockResolvedValue(prismaReport);
+
+    const result = await deleteProjectReportService(3);
+    expect(result).toBe('NO_CONTENT');
+  });
+  it("returns NOT_FOUND if the report isn't found", async () => {
+    vi.mocked(prisma.reportProject.findUnique).mockResolvedValue(null);
+
+    const result = await deleteProjectReportService(3);
+    expect(result).toBe('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR if prisma throws', async () => {
+    vi.mocked(prisma.reportProject.findUnique).mockRejectedValue(new Error('womp womp'));
+
+    const result = await deleteProjectReportService(3);
+    expect(result).toBe('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/report/get-project-reports.test.ts
+++ b/server/tests/projectstest/report/get-project-reports.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '#config/prisma.ts';
+import getProjectReportsService from '#services/projects/get-project-reports.ts';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+vi.mock('#config/prisma.ts', () => ({
+  default: {
+    reportProject: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const prismaReports = [
+  {
+    reportId: 3,
+    userId: 1,
+    projectId: 2,
+    reportText: 'test report',
+  },
+  {
+    reportId: 7,
+    userId: 5,
+    projectId: 6,
+    reportText: 'test report 2',
+  },
+];
+
+describe('getProjectReportsService', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns array of reports', async () => {
+    vi.mocked(prisma.reportProject.findMany).mockResolvedValue(prismaReports);
+
+    const result = await getProjectReportsService();
+    expect(result).toStrictEqual(prismaReports);
+  });
+
+  it('returns NOT_FOUND if there are no reports', async () => {
+    vi.mocked(prisma.reportProject.findMany).mockResolvedValue([]);
+
+    const result = await getProjectReportsService();
+    expect(result).toEqual('NOT_FOUND');
+  });
+
+  it('returns INTERNAL_ERROR if prisma throws', async () => {
+    vi.mocked(prisma.reportProject.findMany).mockRejectedValue(new Error('womp womp'));
+
+    const result = await getProjectReportsService();
+    expect(result).toEqual('INTERNAL_ERROR');
+  });
+});

--- a/server/tests/projectstest/report/report-proj.test.ts
+++ b/server/tests/projectstest/report/report-proj.test.ts
@@ -56,7 +56,7 @@ const prismaReport = {
   reportText: 'test report',
 };
 
-describe('createProjectService', async () => {
+describe('reportProjectService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
Added backend endpoints for creating a project report, deleting reports, and viewing all reports. Includes swagger docs and unit tests. Does include a DB change, so I will make a dump after posting this.