### PR TITLE
Infinite Scrolling on Discover Pages

### DIFF
--- a/client/src/components/PanelBox.tsx
+++ b/client/src/components/PanelBox.tsx
@@ -29,43 +29,25 @@ export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache
     setItemListCopy(itemList);
   }
 
-  /**
-   * Appends more items to the displayed list when the user scrolls to the bottom.
-   * 
-   * Steps:
-   * 1. Reads scrollTop, clientHeight, and scrollHeight from the panel container.
-   * 2. Checks if the scroll position indicates the user has reached the bottom.
-   * 3. Slices the next `itemAddInterval` items from the full itemList and appends them
-   *    to the displayedItems array.
-   * 
-   * Important notes:
-   * - Uses `document.querySelector` to locate the scroll container (can be replaced by useRef for better React practices)
-   * - The original `startIndex` calculation should be `displayedItems.length` to avoid skipping items.
-   */
-  const addItems = () => {
-    const panelBoxName = `${category === 'projects' ? 'project' : 'profile'}-panel-box`;
-    const { scrollTop, scrollHeight, clientHeight } = document.querySelector(panelBoxName)!;
+  // Updated to use native react events
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
 
-    // Check if the user has scrolled to the bottom of the panel box
-    if (scrollTop + clientHeight >= scrollHeight) {
-      const startIndex = displayedItems.length - 1;
-      const newItems = itemList.slice(startIndex, startIndex + itemAddInterval);
-      setDisplayedItems(displayedItems.concat(newItems));
+    if (Math.ceil(scrollTop) + clientHeight >= scrollHeight - 5) {
+      const startIndex = displayedItems.length;
+      
+      // Only add if there is something left
+      if (startIndex < itemList.length) {
+        const newItems = itemList.slice(startIndex, startIndex + itemAddInterval);
+        setDisplayedItems(prevItems => prevItems.concat(newItems));
+      }
     }
   };
 
-  /**
-   * Renders the list of ProjectPanel components inside a scrollable container.
-   * Attaches the addItems scroll handler to implement lazy loading.
-   * 
-   * @returns JSX element containing the project panels
-   */
-  const ProjectPanelBox = () => {
+  // Return directly instead of deferring
+  if (category === 'projects') {
     return (
-      <div
-        className="project-panel-box"
-        onScroll={addItems}
-      >
+      <div className="project-panel-box" onScroll={handleScroll}>
         {displayedItems.length > 0 ? (
           displayedItems.map((item) => {
             const projectId = (item as ProjectWithFollowers).projectId;
@@ -84,30 +66,22 @@ export const PanelBox = ({ category, itemList, itemAddInterval = 0, projectCache
         )}
       </div>
     );
-  };
+  }
 
-  /**
-   * Renders the list of ProfilePanel components inside a scrollable container.
-   * Attaches the addItems scroll handler to implement lazy loading.
-   * 
-   * @returns JSX element containing the profile panels
-   */
-  const ProfilePanelBox = () => {
-    return (
-      <div
-        className="profile-panel-box"
-        onScroll={addItems}
-      >
-        {displayedItems.length > 0 ? (
-          displayedItems.map((profile) => (
-            <ProfilePanel profileData={profile as UserPreview} currentUserId={userId} key={(profile as UserPreview).userId} />
-          ))
-        ) : (
-          <>Sorry, no people here</>
-        )}
-      </div>
-    );
-  };
-
-  return category === 'projects' ? <ProjectPanelBox /> : <ProfilePanelBox />;
+  // Functional else statement
+  return (
+    <div className="profile-panel-box" onScroll={handleScroll}>
+      {displayedItems.length > 0 ? (
+        displayedItems.map((profile) => (
+          <ProfilePanel 
+            profileData={profile as UserPreview} 
+            currentUserId={userId} 
+            key={(profile as UserPreview).userId} 
+          />
+        ))
+      ) : (
+        <>Sorry, no people here</>
+      )}
+    </div>
+  );
 };

--- a/client/src/components/Styles/pages.css
+++ b/client/src/components/Styles/pages.css
@@ -37,6 +37,20 @@
   }
 }
 
+.discover-page {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.discover-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+
 @media only screen and (max-width: 799px) {
   .page {
     left: 0px;

--- a/client/src/components/Styles/profile.css
+++ b/client/src/components/Styles/profile.css
@@ -29,6 +29,8 @@ Profile Panel component style rules
   align-content: start;
   gap: 20px;
   width: 100%;
+  max-height: 35vh;
+  overflow-y: scroll;
 }
 
 .profile-column {

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -40,7 +40,7 @@ Project Panel component style rules
   gap: 20px;
   width: 100%;
   padding-bottom: 10px;
-  max-height: 35vh;
+  max-height: 100%;
   overflow-y: scroll;
 }
 

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -40,6 +40,8 @@ Project Panel component style rules
   gap: 20px;
   width: 100%;
   padding-bottom: 10px;
+  max-height: 35vh;
+  overflow-y: scroll;
 }
 
 .project-panel {

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -121,8 +121,6 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     return [{ data: userSearchData }];
   }, [userSearchData]);
 
-  // Pagination state for projects
-  const [currentProjectPage, setCurrentProjectPage] = useState(1);
   const PROJECTS_PER_PAGE = 6;
 
   // When passing in data for project carousel, pass in the first three projects after getting their details
@@ -312,7 +310,6 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     }
     
     setFilteredProjectList(matches);
-    setCurrentProjectPage(1);
 
     // Preload full project data for search results so the like icon state is available immediately.
     (async () => {
@@ -505,7 +502,6 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
 
     // Set displayed projects
     setFilteredProjectList(tagFilteredList);
-    setCurrentProjectPage(1);
   };
 
   /**
@@ -605,10 +601,6 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     setFilteredUserList(tagFilteredList);
   };
 
-  const totalProjectPages = Math.max(1, Math.ceil(filteredProjectList.length / PROJECTS_PER_PAGE));
-  const startIndex = (currentProjectPage - 1) * PROJECTS_PER_PAGE;
-  const paginatedProjects = filteredProjectList.slice(startIndex, startIndex + PROJECTS_PER_PAGE);
-
   let discoverPanelContents : React.ReactElement;
   if (category == 'projects') {
     if(!dataLoaded && filteredProjectList.length === 0) {
@@ -620,53 +612,14 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     }
     else {
       discoverPanelContents = (
-        <div className="pagination-wrapper">
-          <PanelBox
-            category={category}
-            itemList={filteredProjectList} 
-            itemAddInterval={PROJECTS_PER_PAGE} 
-            projectCache={projectCache}
-            followedProjectIds={followedProjectIds}
-            userId={currentUserId ?? -1}
-          />
-          
-          {/* Pagination Controls */}
-          {filteredProjectList.length > 0 && (
-            <div className="pagination-controls" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '1.5rem', marginTop: '2rem', paddingBottom: '2rem' }}>
-              <button
-              className="pagination-btn" 
-                onClick={() => 
-                  {
-                    setCurrentProjectPage(prev => Math.max(prev - 1, 1));
-
-                    // Scroll up to top of panel
-                    document.getElementsByClassName("discover-carousel")[0]?.scrollIntoView(true);
-                  }}
-                disabled={currentProjectPage === 1}
-                
-              >
-                Previous
-              </button>
-              
-              <span>Page {currentProjectPage} of {totalProjectPages}</span>
-              
-              <button 
-              className="pagination-btn"
-                onClick={() => 
-                  {
-                    setCurrentProjectPage(prev => Math.min(prev + 1, totalProjectPages));
-
-                    // Scroll up to top of panel
-                    document.getElementsByClassName("discover-carousel")[0]?.scrollIntoView(true);
-                  }}
-                disabled={currentProjectPage === totalProjectPages}
-
-              >
-                Next
-              </button>
-            </div>
-          )}
-        </div>
+        <PanelBox
+          category={category}
+          itemList={filteredProjectList} 
+          itemAddInterval={PROJECTS_PER_PAGE} 
+          projectCache={projectCache}
+          followedProjectIds={followedProjectIds}
+          userId={currentUserId ?? -1}
+        />
       );
     }
   } else {

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -637,7 +637,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
 
   // Main render function
   return (
-    <div className="page" tabIndex={-1}>
+    <div className="page discover-page" tabIndex={-1} >
       {/* Search bar and profile/notification buttons */}
       <Header dataSets={ category == 'projects' ? projectDataSet : userDataSet }
           onSearch={ category == 'projects' ? searchProjects : searchUsers }
@@ -652,7 +652,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
         Clicking a tag filter adds it to a list & updates panel display based on that list
         Changes to filters via filter menu are only applied after a confirmation
       */}
-      <main id="main" tabIndex={-1} aria-label='main content'>
+      <main id="main" className="discover-main" tabIndex={-1} aria-label='main content'>
         <DiscoverFilters category={category} updateItemList={updateItemList} />
 
         {/* Panel container. itemAddInterval can be whatever. 25 feels good for now */}

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -623,7 +623,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
         <div className="pagination-wrapper">
           <PanelBox
             category={category}
-            itemList={paginatedProjects} 
+            itemList={filteredProjectList} 
             itemAddInterval={PROJECTS_PER_PAGE} 
             projectCache={projectCache}
             followedProjectIds={followedProjectIds}

--- a/client/src/components/pages/DiscoverAndMeet.tsx
+++ b/client/src/components/pages/DiscoverAndMeet.tsx
@@ -121,7 +121,7 @@ const DiscoverAndMeet = ({ category }: DiscoverAndMeetProps) => {
     return [{ data: userSearchData }];
   }, [userSearchData]);
 
-  const PROJECTS_PER_PAGE = 6;
+  const PROJECTS_PER_PAGE = 12;
 
   // When passing in data for project carousel, pass in the first three projects after getting their details
   // Hide the carousel while the user has an active search (non-empty search input)


### PR DESCRIPTION
Replaced pagination with infinite scroll on the discover and meet pages

As there are only 12 projects in the default database, you'll either have to add some, or change `  const PROJECTS_PER_PAGE = 12;` to a different value.
I am aware that if less projects display than the max your page can hold, infinite scrolling does not work. I figured I'd make a different PR for that since it seems it will take time

Since I am going to continue work on a similar topic, please do not delete my branch after merge