### PR TITLE
projects infinite scrolling grid

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -19,9 +19,11 @@ Project Panel component style rules
 
 #discover-panel-box {
   width: 90%;
-  max-width: 1200px;
   margin: 0 auto 20px;
-  display: block;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  justify-content: center;
 }
 
 /*


### PR DESCRIPTION
Change from block to grid and auto fit all projects to max width allowance so that it fills the whole screen rather than a section, now no longer needed to manually decide a different layout for different media size