### PR TITLE
Updated star to be white on both light and dark mode

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -811,6 +811,7 @@ Project Creator and Editor Popup style rules
   border: none;
   background: transparent;
   right: 9px;
+  --main-text: white;
 }
 
 #selected-thumbnail {


### PR DESCRIPTION
- The black dropshadow allows visibility on white images
- This follows the figma for both light and dark mode
<img width="333" height="192" alt="image" src="https://github.com/user-attachments/assets/3434337c-40ae-4080-8ae2-5b14509fa3ad" />
<img width="340" height="193" alt="image" src="https://github.com/user-attachments/assets/b9f8a14c-5292-464e-ba18-84ec27286fe9" />
