### PR TITLE
project tags box no longer extends down when multiple tags are added

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -711,7 +711,7 @@ Project Creator and Editor Popup style rules
   border-radius: 10px;
   grid-area: search;
   min-width: 150px;
-  max-height: 548px;
+  max-height: 546px;
 }
 
 #project-editor-tag-search-container {
@@ -884,8 +884,9 @@ Project Creator and Editor Popup style rules
   grid-area: select;
   display: flex;
   flex-direction: column;
-  max-height: 427px;
-
+  max-height: 347px;
+  padding-bottom: 26px;
+  
   .error {
     margin-top: 15px;
   }


### PR DESCRIPTION
<img width="1037" height="703" alt="image" src="https://github.com/user-attachments/assets/1a26e5d2-4429-414d-bf72-5c6358a25511" />
