### PR TITLE
Adjusted meet page column breakpoints without changing the discover page

### DIFF
--- a/client/src/components/PanelBox.tsx
+++ b/client/src/components/PanelBox.tsx
@@ -57,6 +57,9 @@ export const PanelBox = ({ category, itemList, projectCache, followedProjectIds,
   // Test these
   const isMobile = useMediaQuery('(max-width: 500px)');
   const isTablet = useMediaQuery('(max-width: 1000px)');
+  const isTabletProfile = useMediaQuery('(max-width: 1040px)');
+  const isSmallDesktop = useMediaQuery('(max-width: 1360px');
+  const isMediumDesktop = useMediaQuery('(max-width: 1640px');
 
   // Early return
   if (!itemList || itemList.length === 0) {
@@ -65,8 +68,19 @@ export const PanelBox = ({ category, itemList, projectCache, followedProjectIds,
 
   // Dynamically determine column count
   let columns = 3; // Default for desktop
-  if (isMobile) columns = 1;
-  else if (isTablet) columns = 2;
+
+  if(category == 'profiles'){
+    columns = 5; // large desktop
+    if (isMediumDesktop) columns = 4;
+    if (isSmallDesktop) columns = 3;
+    if (isMobile) columns = 1;
+    else if (isTabletProfile) columns = 2;
+  }
+  //This is for projects
+  else{
+    if (isMobile) columns = 1;
+    else if (isTablet) columns = 2;
+  }
 
   const masonryContext: MasonryContext = {
     category,


### PR DESCRIPTION
Adjusted the column breakpoints on the meet page to make more sense on desktop while keeping the mobile breakpoints where it makes sense. The Discover page's column breakpoints were left alone through putting it an if/else with my changes. Profiles will cause one set of breakpoints, and Projects will cause another set.