### PR TITLE
Removed overlap between profile columns on mobile

### DIFF
--- a/client/src/components/Styles/profile.css
+++ b/client/src/components/Styles/profile.css
@@ -190,10 +190,11 @@ Profile Panel component style rules
   opacity: 1;
 }
 
-@media (max-width: 660px){
+@media (max-width: 499px){
   .profile-panel{
-    width: clamp(200px, 300px, 300px) !important;
+    width: clamp(180px, 250px, 250px) !important;
     display: flex;
+  
 
     img {
       border-radius: 10px !important;
@@ -204,9 +205,17 @@ Profile Panel component style rules
   }
 }
 
-@media (max-width: 799px){
+@media (min-width: 500px) and (max-width: 555px){
   .profile-panel{
-    width: clamp(200px, 250px, 250px) !important;
+    width: 98% !important;
+    display: flex;
+    
+  }
+}
+
+@media (min-width: 556px) and (max-width: 799px){
+  .profile-panel{
+    width: clamp(180px, 250px, 250px) !important;
     display: flex;
   
 


### PR DESCRIPTION
Profile columns on mobile previously overlapped at some window sizes and now do not