### PR TITLE
Project panel fix on large screens

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -55,7 +55,7 @@ Project Panel component style rules
 
 .project-panel {
   width: 100%;
-  height: 280px;
+  min-height: 280px;
   border: none;
   border-radius: 10px;
   background-color: var(--header-color);
@@ -201,6 +201,7 @@ Project Panel component style rules
 .project-panel:hover {
   transition: 0.2s;
   border-radius: 10px;
+  
   filter: drop-shadow(2px 2px 10px var(--shadow-color));
   /* z-index: 2; */
 


### PR DESCRIPTION
The project panels on the discover page now scale with the size of the screen on large screens, preventing visual bugs when hovering over some portions of the panel. Addresses #1246