### PR TITLE
Invite page css styling

### DIFF
--- a/client/src/components/Styles/acceptInvite.css
+++ b/client/src/components/Styles/acceptInvite.css
@@ -6,6 +6,11 @@ Styling of Accept Project Invite Page (AcceptInvitation.tsx)
 
 /* only the AcceptInvite.tsx background-cover */
 .background-cover:has(#accept-invite-container){
+    /* fixes random guideline issue - this may need to be adjusted in the future */
+    .error
+    {
+        display: none;
+    }
 }
 
 #accept-invite-container

--- a/client/src/components/Styles/acceptInvite.css
+++ b/client/src/components/Styles/acceptInvite.css
@@ -1,0 +1,101 @@
+/* ================================
+
+Styling of Accept Project Invite Page (AcceptInvitation.tsx)
+
+================================ */
+
+/* only the AcceptInvite.tsx background-cover */
+.background-cover:has(#accept-invite-container){
+}
+
+#accept-invite-container
+{
+    width: 95%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: min(60vh, 525px);
+    max-width: 880px;
+    background-color: var(--bg-color);
+    box-shadow: 0px 0px 10px 0px var(--shadow-color);
+    border-radius: 10px;
+    color: var(--primary-color);
+    margin: 0 auto;
+    padding: 0;
+
+    button
+    {
+        width: fit-content;
+        height: 40px;
+        min-height: fit-content;
+        padding: 5px 16px;
+        font-size: 1.25rem;
+        border: none;
+        border-radius: 40px;
+        background-color: var(--primary-color);
+        color: var(--invert-text);
+        font-weight: 700;
+    }
+    #decline-button
+    {
+        background-color: var(--error-delete-color) !important;
+    }
+
+    h1
+    {
+        font-size: 1.5rem;
+        margin-top: min(3.46vh, 34px);
+        margin-bottom: min(3.05vh, 30px);
+        font-weight: 600;
+        color: var(--primary-color);
+    }
+    h2
+    {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--primary-color);
+        margin: min(0.2vh, 2px) 0 min(0.51vh, 5px);
+    }
+    #project-title          /* project title is slightly larger and capitalized */
+    {
+        font-size: 1.5rem;
+    }
+
+    #accept-invite-info
+    {
+        width: 80%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+    }
+
+    #accept-invite-btns
+    {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        width: fit-content;
+        margin: 0 auto;
+    }
+}
+/*
+#accept-invite-modal
+{
+    display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--modal-gradient);
+  background-repeat: no-repeat;
+  z-index: 10;
+  margin: 0 auto;
+}*/

--- a/client/src/components/Styles/acceptInvite.css
+++ b/client/src/components/Styles/acceptInvite.css
@@ -80,9 +80,10 @@ Styling of Accept Project Invite Page (AcceptInvitation.tsx)
     #accept-invite-btns
     {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
-        justify-content: space-between;
-        gap: 10px;
+        justify-content: center;
+        gap: 20px;
         width: fit-content;
         margin: 0 auto;
     }

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -35,7 +35,6 @@ Login and Signup page style rules
   justify-content: center;
   align-items: center;
   height: min(60vh, 525px);
-  max-width: 880px;
   background-color: var(--bg-color);
   box-shadow: 0px 0px 10px 0px var(--shadow-color);
   border-radius: 10px;

--- a/client/src/components/pages/AcceptInvitation.tsx
+++ b/client/src/components/pages/AcceptInvitation.tsx
@@ -23,6 +23,8 @@ const AcceptInvitation = () => {
     // Project info
     const [projectTitle, setProjectTitle] = useState<string | null>(null);
     const [role, setRole] = useState<Role | null>(null);
+    const [ownerFirstName, setOwnerFirstName] = useState<String | null>(null);
+    const [ownerLastName, setOwnerLastName] = useState<String | null>(null);
 
     const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
 
@@ -50,6 +52,9 @@ const AcceptInvitation = () => {
 
             if (res.data) {
                 setProjectTitle(res.data.title);
+                setOwnerFirstName(res.data.owner.firstName);
+                setOwnerLastName(res.data.owner.lastName);
+                
             }
         } catch (err) {
             setError('Fetch Project Error: ' + err);
@@ -127,7 +132,8 @@ const AcceptInvitation = () => {
                         <div id="accept-invite-container">
                             <div id="accept-invite-info">
                                 <h1>Hi, {firstName}!</h1>
-                                <h2>You are invited to <h2 id="project-title">{projectTitle?.toUpperCase() ?? " a project"}</h2></h2>
+                                <h2>{ownerFirstName ?? "The Owner"} {ownerLastName ?? ""} 
+                                    invited you to join <h2 id="project-title">{projectTitle?.toUpperCase() ?? " a project"}</h2></h2>
                                 <p>Your role will be {role?.label ?? "Member"}</p>
                                 <div id="accept-invite-btns">
                                     <button id="decline-button" onClick={handleDecline}>Decline Invite</button>

--- a/client/src/components/pages/AcceptInvitation.tsx
+++ b/client/src/components/pages/AcceptInvitation.tsx
@@ -25,7 +25,6 @@ const AcceptInvitation = () => {
     const [role, setRole] = useState<Role | null>(null);
 
     const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
-    const errorDisplay = useRef<HTMLDivElement>(null);
 
     //#region Helper Methods
     const fetchRole = async () => {
@@ -96,14 +95,6 @@ const AcceptInvitation = () => {
         if (result.error) {
             setError(result.error);
         }
-        else
-        {
-            /* Removes error display if there isn't an error */
-            if (errorDisplay.current)
-            {
-                errorDisplay.current.style.display = "none";
-            }
-        }
         navigate(paths.routes.HOME);
     };
 
@@ -123,14 +114,6 @@ const AcceptInvitation = () => {
         if (result.error) {
             setError(result.error);
         }
-        else {
-            /* Removes error display if there isn't an error */
-            if (errorDisplay.current)
-            {
-                errorDisplay.current.style.display = "none";
-            }
-           
-        }
         navigate(`${paths.routes.PROJECT}?projectID=${projectId}`);
     };
     //#endregion
@@ -138,7 +121,7 @@ const AcceptInvitation = () => {
     return (
         <>
             <div className="background-cover">
-                <div className="error" aria-live="assertive" ref={errorDisplay} role="alert">{error}</div>
+                <div className="error" aria-live="assertive" role="alert">{error}</div>
                 {
                     loggedIn && 
                         <div id="accept-invite-container">

--- a/client/src/components/pages/AcceptInvitation.tsx
+++ b/client/src/components/pages/AcceptInvitation.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 import { getByID, updatePendingMember, deleteMember } from '../../api/projects';
-import { getCurrentAccount, getJobTitles } from '../../api/users';
+import { getCurrentAccount, getJobTitles, getUserByEmail } from '../../api/users';
 import { Role } from '@looking-for-group/shared';
 import "../Styles/acceptInvite.css";
 
@@ -127,8 +127,8 @@ const AcceptInvitation = () => {
                         <div id="accept-invite-container">
                             <div id="accept-invite-info">
                                 <h1>Hi, {firstName}!</h1>
-                                <h2>You are invited to <h2 id="project-title">{projectTitle?.toUpperCase()}</h2></h2>
-                                <p>Your role will be {role?.label}.</p>
+                                <h2>You are invited to <h2 id="project-title">{projectTitle?.toUpperCase() ?? " a project"}</h2></h2>
+                                <p>Your role will be {role?.label ?? "Member"}</p>
                                 <div id="accept-invite-btns">
                                     <button id="decline-button" onClick={handleDecline}>Decline Invite</button>
                                     <button onClick={handleAccept}>Accept Invite</button>

--- a/client/src/components/pages/AcceptInvitation.tsx
+++ b/client/src/components/pages/AcceptInvitation.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import * as paths from '../../constants/routes';
 import { getByID, updatePendingMember, deleteMember } from '../../api/projects';
 import { getCurrentAccount, getJobTitles } from '../../api/users';
 import { Role } from '@looking-for-group/shared';
+import "../Styles/acceptInvite.css";
 
 const AcceptInvitation = () => {
     const navigate = useNavigate(); // Hook for navigation
@@ -24,6 +25,7 @@ const AcceptInvitation = () => {
     const [role, setRole] = useState<Role | null>(null);
 
     const [error, setError] = useState<string>(''); // Error message for missing or incorrect information
+    const errorDisplay = useRef<HTMLDivElement>(null);
 
     //#region Helper Methods
     const fetchRole = async () => {
@@ -94,6 +96,14 @@ const AcceptInvitation = () => {
         if (result.error) {
             setError(result.error);
         }
+        else
+        {
+            /* Removes error display if there isn't an error */
+            if (errorDisplay.current)
+            {
+                errorDisplay.current.style.display = "none";
+            }
+        }
         navigate(paths.routes.HOME);
     };
 
@@ -113,6 +123,14 @@ const AcceptInvitation = () => {
         if (result.error) {
             setError(result.error);
         }
+        else {
+            /* Removes error display if there isn't an error */
+            if (errorDisplay.current)
+            {
+                errorDisplay.current.style.display = "none";
+            }
+           
+        }
         navigate(`${paths.routes.PROJECT}?projectID=${projectId}`);
     };
     //#endregion
@@ -120,15 +138,20 @@ const AcceptInvitation = () => {
     return (
         <>
             <div className="background-cover">
-                <div className="error" aria-live="assertive" role="alert">{error}</div>
+                <div className="error" aria-live="assertive" ref={errorDisplay} role="alert">{error}</div>
                 {
-                    loggedIn && <div>
-                        <h1>Hi, {firstName}!</h1>
-                        <h2>You are invited to {projectTitle}</h2>
-                        <p>Your role will be {role?.label}</p>
-                        <button onClick={handleDecline}>Decline Invite</button>
-                        <button onClick={handleAccept}>Accept Invite</button>
-                    </div>
+                    loggedIn && 
+                        <div id="accept-invite-container">
+                            <div id="accept-invite-info">
+                                <h1>Hi, {firstName}!</h1>
+                                <h2>You are invited to <h2 id="project-title">{projectTitle?.toUpperCase()}</h2></h2>
+                                <p>Your role will be {role?.label}.</p>
+                                <div id="accept-invite-btns">
+                                    <button id="decline-button" onClick={handleDecline}>Decline Invite</button>
+                                    <button onClick={handleAccept}>Accept Invite</button>
+                                </div>
+                            </div>
+                        </div>
                 }
             </div>
         </>


### PR DESCRIPTION
Project title and role will be filled in with proper data (default values are pictured).

If someone wants to implement the inviter's name into the invite request as well, I'd recommend that. I took a look at it and could not figure that out.

<img width="1252" height="924" alt="image" src="https://github.com/user-attachments/assets/8533f646-3a10-441c-98f1-7391543612fd" />
<img width="453" height="923" alt="image" src="https://github.com/user-attachments/assets/b3865a61-1b3a-4d9d-ae50-3250e7e26e9e" />
