### PR TITLE
Made the discover filters and meet filters be able to filter by more than one type consistently

### DIFF
--- a/client/src/components/DiscoverFilters.tsx
+++ b/client/src/components/DiscoverFilters.tsx
@@ -202,14 +202,17 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
     let newActiveTags: Tag[];
 
     const discoverFilters = document.getElementsByClassName('discover-tag-filter');
-    for (let i = 0; i < discoverFilters.length; i++) {
-      discoverFilters[i].classList.remove('discover-tag-filter-selected');
-    }
+    //for (let i = 0; i < discoverFilters.length; i++) {
+    //  discoverFilters[i].classList.remove('discover-tag-filter-selected');
+    //}
 
     if (activeTagFilters.some(t => t.label === tag.label && t.type === tag.type)) {
-      newActiveTags = [];
+      // Remove the tag from the active list
+      newActiveTags = activeTagFilters.filter(t => t.label !== tag.label || t.type !== tag.type);
+      event.currentTarget.classList.remove('discover-tag-filter-selected');
     } else {
-      newActiveTags = [tag];
+      // Add the tag to the active list
+      newActiveTags = [...activeTagFilters, tag];
       event.currentTarget.classList.add('discover-tag-filter-selected');
     }
 
@@ -450,25 +453,25 @@ export const DiscoverFilters: React.FC<DiscoverFiltersProps> = ({ category, upda
                               const selectIndex = isTagEnabled(tag, searchedTags.color);
                               let tempEnabled = enabledFilters;
 
-                              if (tag.type === 'Project Type' || tag.type === 'Purpose' || tag.type === 'Role' || tag.type === 'Major') {
-                                // Remove all other tags of the same type except the one selected
-                                const filterTags = document.querySelector('#filter-tags')!;
-                                const tagList: HTMLCollectionOf<HTMLElement> = filterTags.getElementsByClassName(`tag-button-${searchedTags.color}-selected`) as HTMLCollectionOf<HTMLElement>;
-
-                                for (let i = 0; i < tagList.length; i++) {
-                                  const tagObj: Tag = { label: tagList[i].innerText.trim(), type: tag.type, tagId: -1 };
-                                  const tagTypeIndex = isTagEnabled(tagObj, searchedTags.color);
-
-                                  if (tagList[i].innerText.trim() !== tag.label) {
-                                    tagList[i].classList.replace(
-                                      `tag-button-${searchedTags.color}-selected`,
-                                      `tag-button-${searchedTags.color}-unselected`
-                                    );
-
-                                    tempEnabled = tempEnabled.toSpliced(tagTypeIndex, 1);
-                                  }
-                                }
-                              }
+                              //if (tag.type === 'Project Type' || tag.type === 'Purpose' || tag.type === 'Role' || tag.type === 'Major') {
+                              //  // Remove all other tags of the same type except the one selected
+                              //  const filterTags = document.querySelector('#filter-tags')!;
+                              //  const tagList: HTMLCollectionOf<HTMLElement> = filterTags.getElementsByClassName(`tag-button-${searchedTags.color}-selected`) as HTMLCollectionOf<HTMLElement>;
+//
+                              //  for (let i = 0; i < tagList.length; i++) {
+                              //    const tagObj: Tag = { label: tagList[i].innerText.trim(), type: tag.type, tagId: -1 };
+                              //    const tagTypeIndex = isTagEnabled(tagObj, searchedTags.color);
+//
+                              //    if (tagList[i].innerText.trim() !== tag.label) {
+                              //      tagList[i].classList.replace(
+                              //        `tag-button-${searchedTags.color}-selected`,
+                              //        `tag-button-${searchedTags.color}-unselected`
+                              //      );
+//
+                              //      tempEnabled = tempEnabled.toSpliced(tagTypeIndex, 1);
+                              //    }
+                              //  }
+                              //}
 
                               if (selectIndex === -1) {
                                 // Creates an object to store text and category

--- a/client/src/components/pages/Meet.tsx
+++ b/client/src/components/pages/Meet.tsx
@@ -180,41 +180,42 @@ export const ProfileMeetPage = () => {
 
     let tagFilteredList = items.filter((item) => {
       if (activeTagFilters.length === 0) return true;
-      let matchesAny = false;
+      //let matchesAny = false;
+      let matchesAll = true;
 
       for (const tag of activeTagFilters) {
         // Check for tag label Developer
-        if (tag.label === 'Developer' && item.developer) {
-          matchesAny = true;
+        if (tag.label === 'Developer' && !item.developer) {
+          matchesAll = false;
         }
         // Check for specific skills
         else if (tag.type === 'Developer' || tag.type === 'Designer' || tag.type === 'Soft' || tag.type === 'Audio') {
           const userSkills = item.skills?.map((s) => s?.label?.toLowerCase())
             .filter((s) => typeof s === 'string');
 
-          if (userSkills.includes(tag.label.toLowerCase().trim())) {
-            matchesAny = true;
+          if (!(userSkills.includes(tag.label.toLowerCase().trim()))) {
+            matchesAll = false;
           }
         }
-        else if (tag.label === 'Designer' && item.designer) {
-          matchesAny = true;
+        else if (tag.label === 'Designer' && !item.designer) {
+          matchesAll = false;
         }
         else if (tag.label === 'Audio') {
           //TODO: replace with an item boolean like with designer or developer, probably a backend task
           const userSkills = item.skills?.map((s) => s?.type?.toLowerCase())
             .filter((s) => typeof s === 'string');
 
-          if (userSkills.includes(tag.label.toLowerCase().trim())) matchesAny = true;
+          if (!(userSkills.includes(tag.label.toLowerCase().trim()))) matchesAll = false;
         }
         else if (tag.label === 'Soft') {
           //TODO: replace with an item boolean like with designer or developer, probably a backend task
           const userSkills = item.skills?.map((s) => s?.type?.toLowerCase())
             .filter((s) => typeof s === 'string');
 
-          if (userSkills.includes(tag.label.toLowerCase().trim())) matchesAny = true;
+          if (!(userSkills.includes(tag.label.toLowerCase().trim()))) matchesAll = false;
         }
-        else if (tag.label === 'Other' && !item.designer && !item.developer) {
-          matchesAny = true;
+        else if (tag.label === 'Other' && (item.designer || item.developer)) {
+          matchesAll = false;
         }
         // Check role and major by name since IDs are not unique relative to tags
         /* it seems roles are not yet implimented
@@ -226,12 +227,12 @@ export const ProfileMeetPage = () => {
         else if (tag.type === 'Major' && item.majors) {
           const userMajors = item.majors?.map((s) => s?.label?.toLowerCase())
             .filter((s) => typeof s === 'string');
-          if (userMajors.includes(tag.label.toLowerCase())) {
-            matchesAny = true;
+          if (!(userMajors.includes(tag.label.toLowerCase()))) {
+            matchesAll = false;
           }
         }
       }
-      return matchesAny;
+      return matchesAll;
     });
 
     // If no tags are currently selected, render all projects


### PR DESCRIPTION
This involves bringing back some functionality that was already there before but presumably got wiped by a merge or pull.