### PR TITLE
Added functionlaity to placeholder images

### DIFF
--- a/client/src/components/DiscoverCarousel.tsx
+++ b/client/src/components/DiscoverCarousel.tsx
@@ -4,6 +4,8 @@ import * as paths from '../constants/routes';
 import placeholderThumbnail from '../images/project_temp.png';
 import { ProjectWithFollowers } from "@looking-for-group/shared";
 
+import usePreloadedImage from '../functions/imageLoad.tsx';
+
 type DiscoverCarouselProps = {
   dataList?: ProjectWithFollowers[]
 };
@@ -55,7 +57,7 @@ export const DiscoverCarousel: React.FC<DiscoverCarouselProps> = ({ dataList = [
         <div className='discover-project-image'>
           <a href={`${paths.routes.PROJECT}?projectID=${project.projectId}`} tabIndex={-1}>
             <img
-              src={project.thumbnail?.image ?? placeholderThumbnail}
+              src={usePreloadedImage(`${project.thumbnail?.image}`, placeholderThumbnail)}
               alt={'project image'}
             />
           </a>

--- a/client/src/components/pages/Project.tsx
+++ b/client/src/components/pages/Project.tsx
@@ -21,6 +21,7 @@ import { leaveProject } from "../projectPageComponents/ProjectPageHelper";
 import { MePrivate, ProjectWithFollowers } from "@looking-for-group/shared";
 import { ProjectStatus as ProjectStatusEnums } from "@looking-for-group/shared/enums";
 import AboutFooter from "../AboutFooter";
+import usePreloadedImage from '../../functions/imageLoad';
 
 //Main component for the project page
 /**
@@ -282,6 +283,13 @@ const Project = (userProfile : any) => {
           // }
           const memberUser = member.user; //so i don't have to go user.user.userId or anything
 
+          // Use placeholder image if user does not have a profile picture
+          let userProfile = memberUser.profileImage
+          if(!memberUser.profileImage)
+          {
+            userProfile = profileImage;
+          }
+
           return (
             <a
               key={memberUser.userId}
@@ -290,9 +298,8 @@ const Project = (userProfile : any) => {
             >
               <img
                 className="project-contributor-profile"
-                src={memberUser.profileImage ?? profileImage}
+                src={userProfile!}
                 alt="contributor profile"
-                // Cannot use usePreloadedImage function because this is in a callback
                 onError={(e) => {
                   const profileImg = e.target as HTMLImageElement;
                   profileImg.src = profileImage;


### PR DESCRIPTION
- Updated carousel to have working placeholder images
- Other placeholder images seem to work, such as profile and project pictures
- We should still decide how to display placeholder images for projects where the image fails to load. Possibly adding the title of the project over the image could work?