### PR TITLE
fix project links saving

### DIFF
--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -52,12 +52,14 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
   //Get project ID from search parameters
   const urlParams = new URLSearchParams(window.location.search);
   const navigate = useNavigate();
-  const projectID = urlParams.get("projectID");
 
   // --- Hooks ---
 
   // Stores current project data: represents actual data from the server
   const [projectData, setProjectData] = useState<ProjectWithFollowers>();
+
+  // Stores current project id
+  const [projectID, setProjectID] = useState<number>(0);
 
   // Tracks temporary project data changes before saving: compared against projectData
   const [modifiedProject, setModifiedProject] = useState<PendingProject>();
@@ -175,6 +177,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
 
           setProjectData(data);
           setModifiedProject(data);
+          setProjectID(data.projectId);
           console.log(projectData);
         }
       } catch (err) {
@@ -196,13 +199,9 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
    * @returns void
    */
   const updateLinks = async () => {
-    if (newProject || !projectID) return; // Only for existing projects
-
-    const projectNumID = Number(projectID);
-
     try {
       // Get current socials from database
-      const currentSocialsResponse = await getProjectSocials(projectNumID);
+      const currentSocialsResponse = await getProjectSocials(projectID);
       const currentSocials = currentSocialsResponse.data || [];
 
       // Process each social in the modified project
@@ -215,11 +214,11 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
         if (existingSocial) {
           // Update existing social if URL changed
           if (existingSocial.url !== social.url) {
-            await updateProjectSocial(projectNumID, social.websiteId, { url: social.url });
+            await updateProjectSocial(projectID, social.websiteId, { url: social.url });
           }
         } else {
           // Create new social
-          await addProjectSocial(projectNumID, { websiteId: social.websiteId, url: social.url });
+          await addProjectSocial(projectID, { websiteId: social.websiteId, url: social.url });
         }
       }
 
@@ -230,7 +229,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
 
       for (const currentSocial of currentSocials) {
         if (!modifiedSocialIds.includes(currentSocial.websiteId)) {
-          await deleteProjectSocial(projectNumID, currentSocial.websiteId);
+          await deleteProjectSocial(projectID, currentSocial.websiteId);
         }
       }
     } catch (error) {
@@ -271,6 +270,9 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
     
     //for firefox
     window.addEventListener("pagehide", deleteNoSave, {once: true, passive: false});
+
+    // if not a new project, get project id from url (existing project)
+    if (!newProject) setProjectID(Number(urlParams.get("projectID")));
   }, [open, projectID, newProject]);
 
   const toggleConfirm = async () => {

--- a/server/src/services/projects/socials/add-social.ts
+++ b/server/src/services/projects/socials/add-social.ts
@@ -24,6 +24,7 @@ export const addProjectSocialService = async (
     //can't add multiple socials of the same type
     const hasSocial = await prisma.projectSocials.findFirst({
       where: {
+        projectId: projectId,
         websiteId: data.websiteId,
       },
     });


### PR DESCRIPTION
create project with links: only get project id from url when not editing a new project and save project id when creating new project
add link after created project: also check for same project id, rather than just website id
closes #1273 