### PR TITLE
Changed text links to be more responsive

### DIFF
--- a/client/src/components/Styles/credits.css
+++ b/client/src/components/Styles/credits.css
@@ -45,6 +45,7 @@ Credits link footer style rules
   opacity: 0.85;
   transform: translateY(-1px);
   cursor: pointer;
+  text-decoration: underline solid 3px;
 }
 
 @media only screen and (max-width: 799px) {

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1237,6 +1237,7 @@ Page popup style rules
     transition: none;
     padding: 1px;
     text-align: center;
+    text-decoration: underline;
   }
 
   .filter-tab.selected {

--- a/client/src/components/Styles/profile.css
+++ b/client/src/components/Styles/profile.css
@@ -168,7 +168,12 @@ Profile Panel component style rules
 
 .profile-panel-hover:hover {
   opacity: 1;
+
+  h2 {
+    text-decoration: underline 3px;
+  }
 }
+
 
 .profile-panel:hover .profile-panel-hover {
   position: absolute;

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -36,7 +36,7 @@ Project Panel component style rules
 
 /* Cheap way to work around the padding */
 .masonry {
-  margin: 0 -10px; 
+  margin: 0 -10px;
   height: 100%;
   width: calc(100% + 20px);
   margin-bottom: 60px;
@@ -109,10 +109,11 @@ Project Panel component style rules
     }
   }
 
-  
+
   a {
     text-decoration: none;
   }
+
   .project-image-container {
     position: relative;
     /* display: flex; */
@@ -153,6 +154,10 @@ Project Panel component style rules
       word-break: break-word;
     }
 
+    h2:hover {
+      text-decoration: underline 3px;
+    }
+
     .project-likes {
       display: flex;
       flex-direction: row-reverse;
@@ -187,6 +192,8 @@ Project Panel component style rules
       #heart-filled:hover {
         transform: scale(1.2);
       }
+
+
     }
   }
 
@@ -214,7 +221,7 @@ Project Panel component style rules
     cursor: pointer;
   }
 
-  .project-panel-meta > .project-panel-meta-plus {
+  .project-panel-meta>.project-panel-meta-plus {
     display: none;
   }
 
@@ -940,7 +947,7 @@ Project Creator and Editor Popup style rules
   flex-direction: column;
   max-height: 347px;
   padding-bottom: 26px;
-  
+
   .error {
     margin-top: 15px;
   }
@@ -1880,7 +1887,7 @@ Project page style rules
   padding-right: 1vw;
   padding-left: 1vw;
   width: 94%;
-  align-items:baseline;
+  align-items: baseline;
 
   #tags {
     display: flex;
@@ -1900,6 +1907,7 @@ Project page style rules
     border: 2px solid var(--main-text);
     border-radius: 100px;
     background: none;
+
     p {
       font-size: 1.2rem;
       margin: 0;


### PR DESCRIPTION
Any hyperlinks not attached to buttons had their text underlined so they would stand out more as clickable.

Includes project titles, member names, about link

Closes: #1272 