### PR TITLE
updated width of positions on mobile view to not be off-center

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -3351,10 +3351,6 @@ button#positions-popup-list-item-active {
   #edit-position-details-right {
     flex-wrap: nowrap;
   }
-
-  .positions-popup-info-wrapper {
-    max-width: 100%;
-  }
 }
 
 @media only screen and (max-width: 395px) {
@@ -3408,6 +3404,7 @@ button#positions-popup-list-item-active {
   .positions-popup-info-wrapper {
     margin-right: 0%;
     min-height: fit-content;
+    width: 100%;
   }
 
   /* #project-team-open-positions-info {


### PR DESCRIPTION
<img width="715" height="820" alt="image" src="https://github.com/user-attachments/assets/30d0a5b2-a60a-4a68-a77a-9acdb19440fa" />
<img width="696" height="815" alt="image" src="https://github.com/user-attachments/assets/509e3fc0-64d6-4e8f-b76a-12eb6992c4a4" />
