### PR TITLE
Updated the styling of the to top of screen button

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -2070,16 +2070,17 @@ Image Carousel style rules
   width: 40px;
   height: 40px;
   text-align: center;
-  background: none;
-  border: none;
+  background: var(--header-color);
+  border: 2px solid var(--main-text);
   border-radius: 50px;
+
 
   animation: fadeIn 0.15s ease-in-out;
 
 }
 
 .to-top-button:hover {
-  background-color: var(--header-color);
+  box-shadow: 0px 0px 5px 1px;
 }
 
 .hidden {


### PR DESCRIPTION
<img width="404" height="428" alt="image" src="https://github.com/user-attachments/assets/13e2e3aa-8488-49c0-9321-c1c1a414b681" />

The "top of screen" button looks like this now. This shows light and dark mode, and normal vs hover. This was done to make it more visible and distinct on the page.

Changes:
Applied the same color as the header of the projects at all times and not just on hover
Added a small border to distinguish it from the background some more
Added a tiny box shadow on hover