### PR TITLE
Added project deletion on reload

### DIFF
--- a/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
+++ b/client/src/components/ProjectCreatorEditor/ProjectCreatorEditor.tsx
@@ -244,7 +244,7 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
     if (!open) return;
     if (!saved) {
       toggleConfirm();
-      return; 
+      return;
     }
     // Only delete if this is a new project AND it was not saved yet
     if (projectData && newProject) {
@@ -266,10 +266,10 @@ export const ProjectCreatorEditor: FC<Props> = ({ newProject, mobileView = false
 
   useEffect(() => {
     //for chrome
-    window.addEventListener("beforeunload", deleteNoSave, {once: true, passive: false});
-    
+    window.addEventListener("beforeunload", deleteNoSave, { once: true, passive: false });
+
     //for firefox
-    window.addEventListener("pagehide", deleteNoSave, {once: true, passive: false});
+    window.addEventListener("pagehide", deleteNoSave, { once: true, passive: false });
 
     // if not a new project, get project id from url (existing project)
     if (!newProject) setProjectID(Number(urlParams.get("projectID")));

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -79,16 +79,21 @@ const MyProjects = (userProfile: any) => {
     // User is logged in, pull their data
     if (data) {
       setLoggedIn(data.userId);
-      const projectsRes = await getProjectsByUser();
+      let projectsRes = await getProjectsByUser();
 
       //Get invalid projects
       const invalidProjects = projectsRes.data?.filter((project) =>
         project.title === "My Project" && project.hook.length === 0 && project.description.length === 0);
 
       //Delete invalid projects
+      //If invalidProjects is undefined, there are none
       if (invalidProjects !== undefined) {
         for (let i = 0; i < invalidProjects?.length; i++) {
+          //Delete the project from the database
           deleteProject(invalidProjects[i].projectId);
+
+          //Removes the deleted project from projectsRes so it's not displayed
+          projectsRes.data = projectsRes.data?.filter((project) => !invalidProjects.includes(project));
         }
       }
 

--- a/client/src/components/pages/MyProjects.tsx
+++ b/client/src/components/pages/MyProjects.tsx
@@ -15,6 +15,7 @@ import { ProjectCreatorEditor } from '../ProjectCreatorEditor/ProjectCreatorEdit
 //import api utils
 import { getCurrentUsername, getProjectsByUser } from '../../api/users.ts'
 import { MePrivate, ProjectDetail } from '@looking-for-group/shared';
+import { deleteProject } from '../../api/projects.ts';
 
 /**
  * My Projects page. Creates a customizable page that showcases the user's projects.
@@ -66,7 +67,7 @@ const MyProjects = (userProfile: any) => {
   const getUserProjects = async () => {
     try {
       const res = await getCurrentUsername();
-      setUserProjects({...res.data} as MePrivate)
+      setUserProjects({ ...res.data } as MePrivate)
 
     } catch (e) {
       console.error('error getting projects', e);
@@ -80,16 +81,29 @@ const MyProjects = (userProfile: any) => {
       setLoggedIn(data.userId);
       const projectsRes = await getProjectsByUser();
 
-      if (projectsRes.data && projectsRes.data !== undefined) setProjectsList(projectsRes.data);
+      //Get invalid projects
+      const invalidProjects = projectsRes.data?.filter((project) =>
+        project.title === "My Project" && project.hook.length === 0 && project.description.length === 0);
 
-      //console.log(projectsRes.data);
+      //Delete invalid projects
+      if (invalidProjects !== undefined) {
+        for (let i = 0; i < invalidProjects?.length; i++) {
+          deleteProject(invalidProjects[i].projectId);
+        }
+      }
+
+      if (projectsRes.data && projectsRes.data !== undefined) {
+        setProjectsList(projectsRes.data)
+      };
+
+      console.log(projectsRes.data);
       setUserId(data.username);
-      
     } else {
       //guest
       setUserId("guest");
       setLoggedIn(0);
     }
+
     setDataLoaded(true);
   }
 
@@ -406,7 +420,7 @@ const MyProjects = (userProfile: any) => {
   const projectsModeSwitch = useCallback((newMode: string) => {
     const newFilteredProjects = projectsList.filter((item) => {
       if (newMode === "All") return true;
-      
+
       if (newMode === "Joined") {
         for (let member of item.members) {
           if (member.user.username === userId && item.owner.username !== userId) return true;
@@ -418,7 +432,7 @@ const MyProjects = (userProfile: any) => {
 
       return false;
     });
-    
+
     setProjectMode(newMode);
     setFilteredProjects(newFilteredProjects);
   }, [projectMode, filteredProjects, userId, projectsList]);

--- a/server/src/services/me/get-my-proj.ts
+++ b/server/src/services/me/get-my-proj.ts
@@ -107,6 +107,7 @@ export const getMyProjectsService = async (
     fullProject = fullProject.toSorted(
       (project1, project2) => project1.title.charCodeAt(0) - project2.title.charCodeAt(0),
     );
+
     return fullProject;
   } catch (e) {
     console.error(`Error in getMyProjectsService: ${JSON.stringify(e)}`);


### PR DESCRIPTION
Fixed an issue where if a user reloads the site while on the project creation screen, a project with no data is created.

Issue URL: https://github.com/orgs/LookingforGrp-rit/projects/7/views/1?pane=issue&itemId=199162399&issue=LookingforGrp-rit%7CLookingForGroup%7C1293