### PR TITLE
Updated Carosuel to not display iamges of different projects

### DIFF
--- a/client/src/components/DiscoverCarousel.tsx
+++ b/client/src/components/DiscoverCarousel.tsx
@@ -57,8 +57,13 @@ export const DiscoverCarousel: React.FC<DiscoverCarouselProps> = ({ dataList = [
         <div className='discover-project-image'>
           <a href={`${paths.routes.PROJECT}?projectID=${project.projectId}`} tabIndex={-1}>
             <img
-              src={usePreloadedImage(`${project.thumbnail?.image}`, placeholderThumbnail)}
-              alt={'project image'}
+            // This checks if the image value for the project is null, and if so, uses a placeholder image
+            // If there is a project image value, but the image doesnt exist or the value leads to nothing, 
+            // this will break and return no image, forcing the alt text to display
+              src={project.thumbnail?.image ?? placeholderThumbnail}
+            // A fix for this would be to usePreloadedImage, but for some reason this sometimes displays images of different projects
+            // src={usePreloadedImage(`${project.thumbnail?.image}`, placeholderThumbnail)}
+              alt={project.title}
             />
           </a>
         </div>


### PR DESCRIPTION
- Fixed the issue by not using usePreloadedImage, which for some reason caused the images to somtimes be from different projects
- The one caveat in using this approach is that if there exists a value for the project image but that image doesn't exist, it will display the alt text instead. 
  - This however shouldn't be a problem, as new projects made don't have default images so they use the placeholder and the project add and delete image function works in properly altering and deleting the thumbnail image src