### PR TITLE
Modified the year option in profiles and duration in Create Open Position

### DIFF
--- a/client/src/components/Profile/tabs/AboutTab.tsx
+++ b/client/src/components/Profile/tabs/AboutTab.tsx
@@ -5,7 +5,7 @@ import { Select, SelectButton, SelectOptions } from "../../Select";
 import LabelInputBox from "../../LabelInputBox";
 import { PendingUserProfile } from "../../../../types/types";
 import { userDataManager } from "../../../api/data-managers/user-data-manager";
-import { AcademicYear } from "@looking-for-group/shared/enums";
+import { AcademicYear as RitStatus } from "@looking-for-group/shared/enums";
 import { Major, MePrivate, Role } from "@looking-for-group/shared";
 import { getJobTitles, getMajors } from "../../../api/users";
 
@@ -335,18 +335,18 @@ export const AboutTab = ({
 					}
 
 					<LabelInputBox
-						label={"Year"}
+						label={"RIT Status"}
 						inputType={"none"}
 						forceUnsaved={
-							profile.academicYear !==
-							unmodifiedProfile.academicYear
+							profile.ritStatus !==
+							unmodifiedProfile.ritStatus
 						}>
 						<Select>
 							<SelectButton
 								placeholder="Select"
 								initialVal={
-									profile.academicYear
-										? profile.academicYear
+									profile.ritStatus
+										? profile.ritStatus
 										: ""
 								}
 								callback={(e) => e.preventDefault()}
@@ -355,11 +355,11 @@ export const AboutTab = ({
 							<SelectOptions
 								callback={(e) => {
 									const year = (e.target as HTMLButtonElement)
-										.value as AcademicYear;
+										.value as RitStatus;
 
 									profileAfterAboutChanges = {
 										...profileAfterAboutChanges,
-										academicYear: year as AcademicYear
+										ritStatus: year as RitStatus
 									};
 
 									//Use this for checking what happens when the year is changed
@@ -375,11 +375,11 @@ export const AboutTab = ({
 											type: "canon"
 										},
 										data: {
-											academicYear: year as AcademicYear
+											ritStatus: year as RitStatus
 										}
 									});
 								}}
-								options={Object.values(AcademicYear).map(
+								options={Object.values(RitStatus).map(
 									(yr) => {
 										return {
 											value: yr,

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -80,7 +80,7 @@ const SignUp: React.FC<SignUpProps> = ({ /*setAvatarImage, avatarImage,*/ profil
     googleId: sessionData?.googleId,
     username: '',
     pronouns: pronouns,
-    academicYear: academicYear as AcademicYear,
+    ritStatus: academicYear as AcademicYear,
     bio: bio,
     headline: headline,
     phoneNumber: phoneNumber,

--- a/client/types/types.d.ts
+++ b/client/types/types.d.ts
@@ -379,7 +379,7 @@ interface PendingUserMember extends Exclude<MyMember, "apiUrl"> {
 interface PendingUserProfile extends Exclude<MeDetail, "apiUrl"> {
   profileImage: string | null | PendingProfileImage;
   majors: (MyMajor | PendingMajor)
-  academicYear: AcademicYear | null;
+  ritStatus: AcademicYear | null;
   projects: (MyMember | PendingUserMember)[];
   skills: (MySkill | PendingUserSkill)[];
   socials: (MySocial | PendingUserSocial)[];

--- a/shared/enums.ts
+++ b/shared/enums.ts
@@ -25,7 +25,8 @@ export enum AcademicYear {
   Sophomore = "Sophomore",
   Junior = "Junior",
   Senior = "Senior",
-  Graduate = "Graduate"
+  Graduate = "Graduate",
+  Faculty = "Faculty"
 };
 export enum Visibility {
   Public = "Public",
@@ -55,8 +56,11 @@ export enum JobAvailability {
   Flexible = "Flexible"
 }
 export enum JobDuration {
-  ShortTerm = "Short-term",
-  LongTerm = "Long-term"
+  Days = "Days",
+  Weeks = "Weeks",
+  Months = "Months",
+  Semesters = "Semesters",
+  Years = "Years"
 }
 export enum JobLocation {
   OnSite = "On-Site",

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -27,7 +27,9 @@ export type AcademicYear =
   | "Sophomore"
   | "Junior"
   | "Senior"
-  | "Graduate";
+  | "Graduate"
+  | "Faculty"
+  ;
 export type SkillProficiency =
   | "Novice"
   | "Intermediate"
@@ -44,7 +46,7 @@ export type ProjectStatus =
   | "PostProduction"
   | "Complete";
 export type JobAvailability = "FullTime" | "PartTime" | "Flexible";
-export type JobDuration = "ShortTerm" | "LongTerm";
+export type JobDuration = "Days" | "Weeks" | "Months" | "Semesters" | "Years";
 export type JobLocation = "OnSite" | "Remote" | "Hybrid";
 export type JobCompensation = "Unpaid" | "Paid";
 export type Visibility = "public" | "private";
@@ -762,7 +764,7 @@ export interface MeDetail extends MePreview {
   /**
    * The logged-in user's academic year, or null if unset
    */
-  academicYear: AcademicYear;
+  ritStatus: AcademicYear;
 
   /**
    * The logged-in user's location, such as "Rochester, NY"
@@ -1210,7 +1212,7 @@ export type UpdateUserInput = Partial<
     | "headline"
     | "pronouns"
     | "title"
-    | "academicYear"
+    | "ritStatus"
     | "location"
     | "funFact"
     | "bio"


### PR DESCRIPTION
"Year" in user profiles is now known as "RIT Status", and associated variables have been modified to match.  Faculty option has also been added to it.  "Duration" in the Create Open Position menu now has the days, weeks, months, semesters, and years options instead of short term and long term.