### PR TITLE
Project Overview Long Description

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -3666,6 +3666,16 @@ button#positions-popup-list-item-active {
   margin: 10px 0;
 }
 
+#project-overview-text {
+  color: var(--main-text);
+  font-size: 1rem;
+  line-height: 150%;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: none;
+}
+
 #project-overview-links-section {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Project Overview 2000 Description doesn't allow space for paragraph indentation, its just one big block.

Project Overview Description utilizes hyphens, which probably looks bad, allow word wrap, break word