### PR TITLE
Fixed warped carousel buttons on iOS 18

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -2060,6 +2060,7 @@ Image Carousel style rules
   border-radius: 50%;
   width: 14px;
   height: 14px;
+  padding: 0;
   background-color: var(--header-color);
 }
 


### PR DESCRIPTION
The issue was not repeatable by anyone because I am sitting on an older version of iOS and the new ones have a different UA that already fixed button styling so this isn't necessary.
I figured I would still make the change just in case any real user is like me and has the same issue in the future with production.

closes #1307 