### PR TITLE
Brady profile spacing

### DIFF
--- a/client/src/components/Styles/profile.css
+++ b/client/src/components/Styles/profile.css
@@ -1227,6 +1227,7 @@ New Profile page style rules
         display: flex;
         justify-content: space-between;
         align-items: center;
+        gap: 20px;
 
         >#profile-names {
           display: flex;


### PR DESCRIPTION
Fixes just the internal spacing issue of the profile username and other elements getting too close to each other, just added a gap of 20px in #profile-top-row as it was missing.