### PR TITLE
Added arrows to back and next on profile creation

### DIFF
--- a/client/src/components/SignupProcess/ChooseSkills.tsx
+++ b/client/src/components/SignupProcess/ChooseSkills.tsx
@@ -7,6 +7,8 @@ import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, us
 import { SortableContext, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { SortableTag } from "../ProjectCreatorEditor/tabs/SortableItem";
 import { clampDragWithinContainer } from "../ProjectCreatorEditor/tabs/dragModifiers";
+import arrow from '../../../public/images/icons/s-arrow.png';
+
 
 const skillTabs = ["Developer Skills", "Design Skills", "Soft Skills", "Audio Skills"];
 
@@ -355,6 +357,7 @@ const ChooseSkills: React.FC<ChooseSkillsProps> = ({
 					</div>
 					<div id="signupProcess-btns">
 						<button id="signup-backBtn" onClick={onBack}>
+							<img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
 							Back
 						</button>
 						<button
@@ -366,6 +369,7 @@ const ChooseSkills: React.FC<ChooseSkillsProps> = ({
 							// the user can only move to the next modal when they have selected 5 skills
 							disabled={selectedSkills.length < 3}>
 							Next
+							<img src={arrow} alt="Right arrow" id="signup-rightArw"></img>
 						</button>
 					</div>
 				</div>

--- a/client/src/components/SignupProcess/ChooseSkills.tsx
+++ b/client/src/components/SignupProcess/ChooseSkills.tsx
@@ -357,8 +357,7 @@ const ChooseSkills: React.FC<ChooseSkillsProps> = ({
 					</div>
 					<div id="signupProcess-btns">
 						<button id="signup-backBtn" onClick={onBack}>
-							<img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
-							Back
+							<svg width="70" height="25" id="back" className="color-fill scale-on-hover" aria-label="back"><use href="/assets/icons.svg#back"></use></svg>
 						</button>
 						<button
 							id="signup-nextBtn"

--- a/client/src/components/SignupProcess/CompleteProfile.tsx
+++ b/client/src/components/SignupProcess/CompleteProfile.tsx
@@ -13,6 +13,8 @@ import placeholder from "../../images/blue_frog.png";
 //why do these 2 things have the same name??
 import { RitStatus as RitStatuses, } from "@looking-for-group/shared/enums";
 import { ProfileImageUploader } from "../ImageUploader";
+import arrow from '../../../public/images/icons/s-arrow.png';
+
 
 interface CompleteProfileProps {
 	show: boolean;
@@ -371,6 +373,7 @@ const CompleteProfile: React.FC<CompleteProfileProps> = ({
 					</div>
 					<div id="signupProcess-btns">
 						<button id="signup-backBtn" onClick={onBack}>
+							<img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
 							Back
 						</button>
 						<button
@@ -378,6 +381,7 @@ const CompleteProfile: React.FC<CompleteProfileProps> = ({
 							onClick={onNext}
 							disabled={!(major.length > 0 && ritStatus && validPhoneNum)}>
 							Next
+							<img src={arrow} alt="Right arrow" id="signup-rightArw"></img>
 						</button>
 					</div>
 				</div>

--- a/client/src/components/SignupProcess/CompleteProfile.tsx
+++ b/client/src/components/SignupProcess/CompleteProfile.tsx
@@ -373,8 +373,7 @@ const CompleteProfile: React.FC<CompleteProfileProps> = ({
 					</div>
 					<div id="signupProcess-btns">
 						<button id="signup-backBtn" onClick={onBack}>
-							<img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
-							Back
+							<svg width="70" height="25" id="back" className="color-fill scale-on-hover" aria-label="back"><use href="/assets/icons.svg#back"></use></svg>
 						</button>
 						<button
 							id="signup-nextBtn"

--- a/client/src/components/SignupProcess/CreateProfileRedirect.tsx
+++ b/client/src/components/SignupProcess/CreateProfileRedirect.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler } from 'react';
+import arrow from '../../../public/images/icons/s-arrow.png';
 
 interface CreateProfileRedirectProps {
     show: boolean;
@@ -21,10 +22,12 @@ const CreateProfileRedirect: React.FC<CreateProfileRedirectProps> = ({ show, onN
 
                     <div id="signupProcess-btns">
                         <button id="signup-backBtn" onClick={onBack}>
+                            <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
                             Back
                         </button>
                         <button id="signup-nextBtn" onClick={onNext}>
                             Next
+                            <img src={arrow} alt="Right arrow" id="signup-rightArw"></img>
                         </button>
                     </div>
                 </div>

--- a/client/src/components/SignupProcess/CreateProfileRedirect.tsx
+++ b/client/src/components/SignupProcess/CreateProfileRedirect.tsx
@@ -22,8 +22,7 @@ const CreateProfileRedirect: React.FC<CreateProfileRedirectProps> = ({ show, onN
 
                     <div id="signupProcess-btns">
                         <button id="signup-backBtn" onClick={onBack}>
-                            <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
-                            Back
+                            <svg width="70" height="25" id="back" className="color-fill scale-on-hover" aria-label="back"><use href="/assets/icons.svg#back"></use></svg>
                         </button>
                         <button id="signup-nextBtn" onClick={onNext}>
                             Next

--- a/client/src/components/SignupProcess/GetStarted.tsx
+++ b/client/src/components/SignupProcess/GetStarted.tsx
@@ -44,8 +44,7 @@ const GetStarted: React.FC<GetStartedProps> = ({ show, onBack, onCreateProject, 
 
           <div id="signupProcess-btns">
             <button id="signup-backBtn" onClick={onBack}>
-              <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
-              Back
+              <svg width="70" height="25" id="back" className="color-fill scale-on-hover" aria-label="back"><use href="/assets/icons.svg#back"></use></svg>
             </button>
           </div>
         </div>

--- a/client/src/components/SignupProcess/GetStarted.tsx
+++ b/client/src/components/SignupProcess/GetStarted.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler } from 'react';
+import arrow from '../../../public/images/icons/s-arrow.png';
 
 interface GetStartedProps {
   show: boolean;
@@ -43,6 +44,7 @@ const GetStarted: React.FC<GetStartedProps> = ({ show, onBack, onCreateProject, 
 
           <div id="signupProcess-btns">
             <button id="signup-backBtn" onClick={onBack}>
+              <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
               Back
             </button>
           </div>

--- a/client/src/components/SignupProcess/TermsOfService.tsx
+++ b/client/src/components/SignupProcess/TermsOfService.tsx
@@ -57,8 +57,7 @@ const TermsOfService: React.FC<TermsOfServiceProps> = ({ show, onBack, onNext })
 
           <div id="signupProcess-btns">
             <button id="signup-backBtn" onClick={onBack}>
-              <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
-              Back
+              <svg width="70" height="25" id="back" className="color-fill scale-on-hover" aria-label="back"><use href="/assets/icons.svg#back"></use></svg>
             </button>
             <div id="accept-tos-section">
                 <input type="checkbox" id="tos-checkbox" name="tos" onChange={() => setIsChecked(!isChecked)}/>

--- a/client/src/components/SignupProcess/TermsOfService.tsx
+++ b/client/src/components/SignupProcess/TermsOfService.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler, useRef, useState } from 'react';
+import arrow from '../../../public/images/icons/s-arrow.png';
 
 interface TermsOfServiceProps {
   show: boolean;
@@ -56,6 +57,7 @@ const TermsOfService: React.FC<TermsOfServiceProps> = ({ show, onBack, onNext })
 
           <div id="signupProcess-btns">
             <button id="signup-backBtn" onClick={onBack}>
+              <img src={arrow} alt="Left arrow" id="signup-leftArw"></img>
               Back
             </button>
             <div id="accept-tos-section">
@@ -64,6 +66,7 @@ const TermsOfService: React.FC<TermsOfServiceProps> = ({ show, onBack, onNext })
             </div>
             <button id="signup-nextBtn" onClick={onNext} ref={nextBtn} disabled={!isChecked}>
               Next
+              <img src={arrow} alt="Right arrow" id="signup-rightArw"></img>
             </button>
           </div>
         </div>

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -477,6 +477,15 @@ Signup process modal style rules
   color: var(--primary-color);
 }
 
+#signup-rightArw,
+#signup-leftArw {
+  color: var(--primary-color);
+  width: 20px;
+}
+
+#signup-rightArw {
+  transform: rotate(0.5turn);
+}
 #accept-tos-btn {
   width: fit-content;
 }


### PR DESCRIPTION
I couldn't find #next in the icon svg so i just manually added an arrow on the next button but it looks kinda messed up so if there IS a next icon in the svg please let me know and I will change it. Or maybe a UI/UX person can add that to the svg in a new issue
<img width="1046" height="598" alt="image" src="https://github.com/user-attachments/assets/20021172-8c44-4b3d-a8ac-e81597a83d13" />
