### PR TITLE
Reduce size of heart icon on mobile

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -246,10 +246,6 @@ Project Panel component style rules
         a {
           padding-right: 4px;
         }
-
-        svg {
-          transform: scale(1.6);
-        }
       }
     }
   }


### PR DESCRIPTION
before: 
<img width="880" height="1833" alt="image" src="https://github.com/user-attachments/assets/e83c1a85-716c-4cc0-a614-1f68b6c9a75c" />

after: 
<img width="852" height="1822" alt="image" src="https://github.com/user-attachments/assets/3537339f-b739-46c8-a0a3-ee4a47145091" />

This change is removing code that specifically makes it bigger at smaller screen sizes, so maybe the larger size is better. I could also be convinced to make the size between the before and after