### PR TITLE
changed z-index of bottom bar for mobile

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -805,7 +805,7 @@ Sidebar Nav style rules
     position: fixed;
     bottom: 10px;
     background-color: var(--border-color);
-    z-index: 10;
+    z-index: 3;
   }
 
   .ProfileContainer {

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -4151,7 +4151,7 @@ My projects page style rules
   padding-left: calc((100vw - 160px) / 14);
   padding-right: calc((100vw - 160px) / 14);
   background: var(--sidebar-gradient);
-  z-index: 10;
+  z-index: 3;
 
   svg {
     filter: invert(1) saturate(0) brightness(1);


### PR DESCRIPTION
This means that the bottom bar will appear below any pop-ups, leaving more space for said pop-ups. It also will make those options inaccessible while in a pop-up, and attempting to click on them will close the pop-up, just like on desktop