### PR TITLE
fixed lines that were visible (project team tab)

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -1253,9 +1253,9 @@ Project Creator and Editor Popup style rules
   align-content: flex-start;
   justify-content: center;
   border-radius: 10px;
-  border: 1px solid var(--border-color);
   background: var(--bg-color);
   gap: 10px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.10);
 }
 
 .project-editor-project-member {


### PR DESCRIPTION
Just removed the border around the content box and added shadow to current team box. The tabs no longer have a line under them, and the current team / open positions content boxes match styling

Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/1641