### PR TITLE
Removed some css causing 2 outlines for search bar

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1726,15 +1726,6 @@ Search style rules
   outline: inherit;
 }
 
-
-.search-input:focus,
-.search-input:focus-visible {
-  border-color: var(--primary-color);
-  border-width: 0;
-  border-bottom-width: 3px;
-  border-style: solid;
-}
-
 .search-input::placeholder {
   color: var(--primary-color);
   font: inherit;


### PR DESCRIPTION
Before: 
<img width="770" height="77" alt="image" src="https://github.com/user-attachments/assets/ec8a225a-8fc8-4294-b42d-6bcde0840af7" />
After: 
<img width="733" height="65" alt="image" src="https://github.com/user-attachments/assets/f77c7b88-9cbc-42be-9ee7-37e566e1bb60" />
