### PR TITLE
Fixed request review popup overlap with approval status text

### DIFF
--- a/client/src/components/MyProjectsDisplayGrid.tsx
+++ b/client/src/components/MyProjectsDisplayGrid.tsx
@@ -184,10 +184,10 @@ const MyProjectsDisplayGrid = ({ projectData, approvalStatus, }: MyProjectsDispl
                         if (projectData) requestProjectReview(projectData.projectId);
                       }}
                       >
-                        request review
+                        Request Review
                       </PopupButton>
                       <PopupButton buttonId="request-cancel-button">
-                        cancel
+                        Cancel
                       </PopupButton>
                     </div>
                   </div>

--- a/client/src/components/MyProjectsDisplayList.tsx
+++ b/client/src/components/MyProjectsDisplayList.tsx
@@ -183,10 +183,10 @@ const MyProjectsDisplayList = ({ projectData, approvalStatus, }: MyProjectsDispl
                         if (projectData) requestProjectReview(projectData.projectId);
                       }}
                       >
-                        request review
+                        Request Review
                       </PopupButton>
                       <PopupButton buttonId="request-cancel-button">
-                        cancel
+                        Cancel
                       </PopupButton>
                     </div>
                   </div>

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -4443,17 +4443,10 @@ My projects page style rules
   box-sizing: border-box;
 }
 
-.txt {
-  font-size: 12px;
-  font-weight: bold;
-  color: black;
-  z-index: 1;
-}
-
 .symbol {
   position: absolute;
   top: -25px;
-  z-index: 0;
+  /* z-index: 0; */
 
   width: 40px !important;
   height: 40px !important;
@@ -4467,6 +4460,13 @@ My projects page style rules
   fill: black !important;
 
   background-color: inherit;
+}
+
+.txt {
+  position: relative;
+  font-size: 12px;
+  font-weight: bold;
+  color: black;
 }
 
 .approved {

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -4446,7 +4446,6 @@ My projects page style rules
 .symbol {
   position: absolute;
   top: -25px;
-  /* z-index: 0; */
 
   width: 40px !important;
   height: 40px !important;


### PR DESCRIPTION
Before:
<img width="1331" height="677" alt="Screenshot 2026-06-30 at 10 54 44 AM" src="https://github.com/user-attachments/assets/eb9aad2c-4289-40c9-b91e-810650275857" />
Now:
<img width="1331" height="677" alt="Screenshot 2026-06-30 at 10 54 51 AM" src="https://github.com/user-attachments/assets/301932d2-e446-48ee-a503-ce76cdb88f95" />
