### PR TITLE
Profile Edit Location

### DIFF
--- a/client/src/components/Profile/tabs/AboutTab.tsx
+++ b/client/src/components/Profile/tabs/AboutTab.tsx
@@ -402,6 +402,7 @@ export const AboutTab = ({
 					<LabelInputBox
 						label={"Location"}
 						inputType={"single"}
+						maxLength={150}
 						value={profile.location}
 						initialValue={unmodifiedProfile.location}
 						onChange={(e) => {


### PR DESCRIPTION
Location is capped at 150 characters but in the user edit, you're able to add more than 150 characters but beyond that, it does not allow saving at all, added a cap that does not let you add more characters than 150 so that it can actually save