### PR TITLE
Notifications styling

### DIFF
--- a/client/src/components/NotificationsDropdown.tsx
+++ b/client/src/components/NotificationsDropdown.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Dropdown, DropdownButton, DropdownContent } from "./Dropdown";
 import { useNotifications } from "../hooks/useNotifications";
 import { getNotification } from "../api/notifications";
+import DOMPurify from 'dompurify';
 import type {
   NotificationPreview,
   NotificationDetail,
@@ -59,6 +60,10 @@ const NotificationsPanel: React.FC<PanelProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const sanitizedData = (dirty: string): string => {
+    return DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true } });
+  };
+
   // Open/close a notification: marks it read and lazily loads its message body
   // (previews don't include the message, so we fetch the detail on demand).
   const handleSelect = async (n: NotificationPreview) => {
@@ -97,18 +102,12 @@ const NotificationsPanel: React.FC<PanelProps> = ({
             >
               <button
                 type="button"
-                className="notification-main"
+                className="notification-open"
                 onClick={() => void handleSelect(n)}
               >
                 {!n.hasBeenRead && <span className="notification-dot" aria-hidden />}
-                <span className="notification-text">
-                  <span className="notification-subject">{n.subjectLine}</span>
-                  {expandedId === n.notificationId &&
-                    details[n.notificationId] && (
-                      <span className="notification-message">
-                        {details[n.notificationId].message}
-                      </span>
-                    )}
+                <span className="notification-subject">
+                  {n.subjectLine}
                 </span>
                 <span className="notification-time">
                   {formatRelativeTime(n.timeSent)}
@@ -125,6 +124,15 @@ const NotificationsPanel: React.FC<PanelProps> = ({
               >
                 &times;
               </button>
+              {expandedId === n.notificationId &&
+                details[n.notificationId] && (
+                  <p
+                    className="notification-message"
+                    dangerouslySetInnerHTML={
+                      { __html: sanitizedData(details[n.notificationId].message) }
+                    }>
+                  </p>
+                )}
             </li>
           ))}
         </ul>

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1815,18 +1815,24 @@ Dropdown style rules
 }
 
 #notifications-panel {
+  position: relative;
   width: min(340px, 90vw);
   max-height: 70vh;
   overflow-y: auto;
   background-color: var(--header-color);
   border-radius: 10px;
   box-shadow: 0px 0px 10px 0px var(--shadow-color);
-  padding: 8px 0;
   text-align: left;
+  scrollbar-color: var(--text-color) var(--header-color);
+  scrollbar-width: thin;
 }
 
 #notifications-panel .notifications-header {
-  padding: 6px 16px 10px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: var(--header-color);
+  padding: 10px 16px;
   font-weight: 700;
   font-size: 1rem;
   color: var(--primary-color);
@@ -1852,6 +1858,7 @@ Dropdown style rules
 #notifications-panel .notification-item {
   display: flex;
   align-items: stretch;
+  flex-wrap: wrap;
   border-bottom: 1px solid var(--bg-color);
 }
 
@@ -1859,10 +1866,10 @@ Dropdown style rules
   background-color: var(--bg-color);
 }
 
-#notifications-panel .notification-main {
+#notifications-panel .notification-open {
   flex: 1;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   background: none;
   border: none;
@@ -1871,38 +1878,48 @@ Dropdown style rules
   text-align: left;
   cursor: pointer;
   color: var(--main-text);
+  will-change: filter;
+  backface-visibility: hidden;
 }
 
-#notifications-panel .notification-main:hover {
-  filter: brightness(1.08);
+#notifications-panel .notification-open:hover {
+  filter: contrast(5);
 }
 
 #notifications-panel .notification-dot {
   flex-shrink: 0;
   width: 8px;
   height: 8px;
-  margin-top: 5px;
   border-radius: 50%;
   background-color: #f14f76;
 }
 
-#notifications-panel .notification-text {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
 #notifications-panel .notification-subject {
+  font-size: 0.85rem;
   font-weight: 600;
   word-break: break-word;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 #notifications-panel .notification-message {
   font-size: 0.85rem;
   color: var(--main-text);
   font-weight: 400;
+  margin: 8px 8px 12px 14px;
+  padding-left: 10px;
   word-break: break-word;
+  border-left: 2px solid var(--primary-color);
+  animation: slideDown 1s cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 #notifications-panel .notification-time {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "body-parser": "^2.2.2",
         "cors": "^2.8.6",
         "crypto": "^1.0.1",
+        "dompurify": "^3.4.11",
         "es-shim-unscopables": "^1.1.0",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.4",
@@ -3447,6 +3448,13 @@
         "@types/serve-static": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -5621,6 +5629,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "body-parser": "^2.2.2",
     "cors": "^2.8.6",
     "crypto": "^1.0.1",
+    "dompurify": "^3.4.11",
     "es-shim-unscopables": "^1.1.0",
     "esbuild": "^0.28.1",
     "eslint": "^9.39.4",

--- a/server/src/notification-templates/invite-received-notification-builder.ts
+++ b/server/src/notification-templates/invite-received-notification-builder.ts
@@ -57,10 +57,10 @@ export class InviteReceivedNotificationBuilder implements NotificationBuilder {
       },
     });
 
-    const clientDomain = process.env.CLIENT_URL as string;
-    const inviteLink = `${clientDomain}/acceptInvite/${String(data?.requestId)}`;
-    const projectLink = `${clientDomain}/project/projectID=${String(data?.projectId)}`;
-    const profileLink = `${clientDomain}/profile?userID=${String(data?.projects.userId)}`;
+    const clientUrl = process.env.CLIENT_URL ?? 'http://localhost:5173';
+    const inviteLink = `${clientUrl}/acceptInvite/${String(data?.requestId)}`;
+    const projectLink = `${clientUrl}/project?projectID=${String(data?.projectId)}`;
+    const profileLink = `${clientUrl}/profile?userID=${String(data?.projects.userId)}`;
     const projectOwnerName = data?.projects.users.preferredName as string;
 
     //--BUILDING NOTIFICATION--//
@@ -68,21 +68,19 @@ export class InviteReceivedNotificationBuilder implements NotificationBuilder {
     notification.subjectLine = `You've been invited to join ${data?.projects.title as string}`;
 
     // building the message
-    notification.message = `Hello ${data?.users.preferredName as string},\n\n`;
-    notification.message += `You have been invited to join ${data?.projects.title as string} `;
-    notification.message += `as a ${roleData?.label as string}.\n\n`;
+    notification.message = `Hello ${data?.users.preferredName as string},<br /><br />`;
+    notification.message += `You have been invited to join <strong>${data?.projects.title as string}</strong> `;
+    notification.message += `as a <strong>${roleData?.label as string}</strong>.<br /><br />`;
     if (message) {
-      notification.message += `The owner included a message for you:\n `;
-      notification.message += `${message}\n\n`;
+      notification.message += `${projectOwnerName} included a message for you:<br /> `;
+      notification.message += `"${message}"<br /><br />`;
     }
-    notification.message += `You can view ${projectOwnerName}'s profile at `;
-    notification.message += `<a href="${profileLink}">${profileLink}</a> `;
-    notification.message += `and you can view the project at `;
-    notification.message += `<a href="${projectLink}">${projectLink}</a>. `;
-    notification.message += `To accept the invite, go to `;
-    notification.message += `<a href="${inviteLink}">${inviteLink}</a>. `;
-    notification.message += `If you think this is a mistake, you may safely ignore this message.\n\n`;
-    notification.message += `We wish you a good day!`;
+    notification.message += `You can view <a href="${profileLink}">${projectOwnerName}'s profile</a> `;
+    notification.message += `and the <a href="${projectLink}">project page</a>.<br /><br />`;
+    notification.message += `To accept the invite, click <a href="${inviteLink}">here</a>.<br /><br />`;
+    notification.message += `If you think this is a mistake, you may safely ignore this message.<br /><br />`;
+    notification.message += `We wish you a good day!<br />`;
+    notification.message += `LFG Team`;
 
     return notification;
   }

--- a/server/src/notification-templates/project-approved-notification-builder.ts
+++ b/server/src/notification-templates/project-approved-notification-builder.ts
@@ -37,9 +37,10 @@ export class ProjectApprovedNotificationBuilder implements NotificationBuilder {
 
     // building message
     let message = `Hello ${data?.users.preferredName as string},`;
-    message += `\n\nYour project, ${data?.title as string}, has been approved. `;
+    message += `<br /><br />Your project, ${data?.title as string}, has been approved. `;
     message += `People can now view, like, and request to join your project.`;
-    message += `\n\nWe wish you luck in all your endeavors!`;
+    message += `<br /><br />We wish you luck in all your endeavors!`;
+    message += `<br />LFG Team`;
 
     notification.message = message;
 

--- a/server/src/notification-templates/project-rejected-notification-builder.ts
+++ b/server/src/notification-templates/project-rejected-notification-builder.ts
@@ -47,15 +47,16 @@ export class ProjectRejectedNotificationBuilder implements NotificationBuilder {
     notification.subjectLine = `The approval request for your project, ${data?.title as string}, has been rejected.`;
 
     // building the message
-    notification.message = `Hello ${data?.users.preferredName as string},\n\n`;
+    notification.message = `Hello ${data?.users.preferredName as string},<br /><br />`;
     notification.message += `Unfortunately, the approval request for your project, ${data?.title as string}, has been rejected. `;
     if (reason) {
-      notification.message += `Here is the reason provided:\n\n`;
-      notification.message += `"${reason}"\n\n`;
+      notification.message += `Here is the reason provided:<br /><br />`;
+      notification.message += `"${reason}"<br /><br />`;
     }
     notification.message += `If you wish to again request approval, please make the appropriate changes to your project. `;
-    notification.message += `Our terms of service can be located at ${process.env.CLIENT_URL as string}/about.\n\n`;
-    notification.message += `We wish you a good day.`;
+    notification.message += `You can review our <a href="${process.env.CLIENT_URL ?? 'http://localhost:5173'}/about">Terms of Service</a>.<br /><br />`;
+    notification.message += `We wish you a good day.<br />`;
+    notification.message += `LFG Team`;
 
     return notification;
   }

--- a/server/src/notification-templates/project-unapproved-notification-buildier.ts
+++ b/server/src/notification-templates/project-unapproved-notification-buildier.ts
@@ -41,13 +41,14 @@ export class ProjectUnapprovedNotificationBuilder implements NotificationBuilder
     notification.subjectLine = `Your project, ${data?.title as string}, has been taken down.`;
 
     // building the message
-    notification.message = `Hello ${data?.users.preferredName as string},\n\n`;
+    notification.message = `Hello ${data?.users.preferredName as string},<br /><br />`;
     notification.message += `Unfortunately, your project ${data?.title as string} has been taken down. `;
-    notification.message += `Here is the reason provided:\n\n`;
-    notification.message += `${reason}\n\n`;
+    notification.message += `Here is the reason provided:<br /><br />`;
+    notification.message += `"${reason}"<br /><br />`;
     notification.message += `If you wish to have this project reapproved, please make the necessary changes. `;
-    notification.message += `Our terms of service can be located at ${process.env.CLIENT_URL as string}/about.\n\n`;
-    notification.message += `We wish you a good day.`;
+    notification.message += `You can review our <a href="${process.env.CLIENT_URL ?? 'http://localhost:5173'}/about">Terms of Service</a>.<br /><br />`;
+    notification.message += `We wish you a good day.<br />`;
+    notification.message += `LFG Team`;
 
     return notification;
   }

--- a/server/src/notification-templates/request-to-join-notification-builder.ts
+++ b/server/src/notification-templates/request-to-join-notification-builder.ts
@@ -58,25 +58,28 @@ export class RequestToJoinNotificationBuilder implements NotificationBuilder {
     const requesterLastName = data?.users.lastName as string;
     const requesterUsername = data?.users.username as string;
     const roleName = roleData?.label as string;
-    const requesterProfileLink = `${process.env.CLIENT_URL as string}/profile?userID=${prospectiveMemberId.toString()}`;
-    const acceptRequestLink = `$`;
+    const requesterProfileLink = `${process.env.CLIENT_URL ?? 'http://localhost:5173'}/profile?userID=${prospectiveMemberId.toString()}`;
+    const acceptRequestLink = `${process.env.CLIENT_URL ?? 'http://localhost:5173'}/acceptApplication/${data?.requestId.toString()}`;
 
     //--BUILDING NOTIFICATION--//
     notification.receiverId = body.ownerUserId;
     notification.subjectLine = `Request to join ${projectTitle} from ${requesterName}`;
 
     // building message
-    notification.message = `Hello ${ownerName},\n\n`;
-    notification.message += `${requesterName} ${requesterLastName} (${requesterUsername}@g.rit.edu) `;
-    notification.message += `has requested to join your project ${projectTitle} as a ${roleName}.\n\n  `;
+    notification.message = `Hello ${ownerName},<br /><br />`;
+    notification.message += `<strong>${requesterName} ${requesterLastName}</strong> (${requesterUsername}@g.rit.edu) `;
+    notification.message += `has requested to join your project <strong>${projectTitle}</strong> as a <strong>${roleName}</strong>.<br /><br />  `;
     if (body.message) {
-      notification.message += `${requesterName} has provided a message:\n`;
-      notification.message += body.message;
+      notification.message += `${requesterName} has provided a message:<br />`;
+      notification.message += `"${body.message}"<br /><br />`;
     }
-    notification.message += `You may view the requester's profile at `;
-    notification.message += `<a href="${requesterProfileLink}">${requesterProfileLink}</a>. `;
-    notification.message += `You may respond to their invite by going to `;
-    notification.message += `<a href="${acceptRequestLink}">${acceptRequestLink}</a>.`;
+    notification.message += `You may view the `;
+    notification.message += `<a href="${requesterProfileLink}">requester's profile</a>.<br /><br />`;
+    notification.message += `To respond to the application, `;
+    notification.message += `<a href="${acceptRequestLink}">click here</a>.<br /><br />`;
+    notification.message += `If you think this is a mistake, you may safely ignore this message.<br /><br />`;
+    notification.message += `We wish you a good day!<br />`;
+    notification.message += `LFG Team`;
 
     return notification;
   }


### PR DESCRIPTION
**!! run `npm i` before testing !!**

- Changed message template to use <br /> instead of \n for line breaks. 
- Styled notification dropdown.

If you want to test it yourself:

1. You need Mailpit installed because notifications are sent after the emails (install it [here](https://mailpit.axllent.org)).
2. After Mailpit is installed, run `mailpit` in the terminal to start Mailpit.
3. Add `VITE_DEV_ID=2` back into your client .env and comment out `VITE_GOOGLE_CLIENT_ID` and `VITE_API_BASE` (Now, you're logged in as one of the test users).
4. Send an invitation to yourself.
5. Comment out the `VITE_DEV_ID=2` and uncomment the other two variables too.
6. Now, you should see a notification (you might need to refresh the page).

Or if you don't want to go through that, here's a video of how it looks right now:

https://github.com/user-attachments/assets/462fa200-9a2c-49cd-8719-342020fc396c

