### PR TITLE
Fixed carousel to prevent title and learn more from being cut off

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -456,9 +456,10 @@ Image carousel style rules
   }
 
   .discover-project-image {
-    max-width: fit-content;
-    width: auto;
-    height: 100%;
+    min-width: 100%;
+    height: auto;
+    max-height: 325px;
+    border-radius: 0;
   }
 
   .discover-project-about {


### PR DESCRIPTION
- Affects screen widths 1020px and fewer
- Also updated image border on smaller screen widths to be uniform