### PR TITLE
Profile contents no longer spill out of box on mobile

### DIFF
--- a/client/src/components/Styles/profile.css
+++ b/client/src/components/Styles/profile.css
@@ -1535,6 +1535,7 @@ New Profile page style rules
 
     #profile-info {
       margin: 10px;
+      width: calc(100% - 20px);
 
       #profile-names {
         align-items: baseline;


### PR DESCRIPTION
before
<img width="407" height="842" alt="image" src="https://github.com/user-attachments/assets/60dd89d7-2d05-488a-8ee2-3309b8a18b34" />


after
<img width="397" height="335" alt="image" src="https://github.com/user-attachments/assets/b0eba9d4-4bdf-462d-8543-b16df09ed9d6" />

Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/1757
