### PR TITLE
Message open position bug 

### DIFF
--- a/client/src/components/TeamPositionsPanel.tsx
+++ b/client/src/components/TeamPositionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 import { ProjectWithFollowers } from "@looking-for-group/shared";
 import profileImage from "../images/lfrog.png";
@@ -21,6 +21,7 @@ interface TeamPositionsPanelProps {
 
 export const TeamPositionsPanel = ({ currentUserId, displayedProject, viewedPosition, setViewedPosition }: TeamPositionsPanelProps) => {
   const navigate = useNavigate();
+  const location = useLocation(); // Hook to access the current location
 
   const currentJob = displayedProject.jobs?.[viewedPosition];
   const jobContact = useMemo(() => {
@@ -38,14 +39,12 @@ export const TeamPositionsPanel = ({ currentUserId, displayedProject, viewedPosi
   const [quickApplyOpen, setQuickApplyOpen] = useState<boolean>(false);
   const [requestSent, setRequestSent] = useState<boolean>(false);
 
-  const handleQuickApply = async () => {
-    // redirect to login if not logged in
-    if (!currentUserId) {
-      navigate(paths.routes.LOGIN, {
-        state: { from: location }
-      });
-      return;
-    }
+  /**
+   * Handles application and updates the application status message
+   * @returns Void
+   */
+  const handleQuickApply = async (): Promise<void> => {
+    if (!currentUserId) return;
 
     try {
       await requestToJoin(displayedProject.projectId, {
@@ -62,8 +61,18 @@ export const TeamPositionsPanel = ({ currentUserId, displayedProject, viewedPosi
     setRequestSent(true);
   };
 
-  const checkApplied = async (jobIndex: number) => {
-    if (!currentUserId) return;
+  /**
+   * Checks whether the current user has already applied for or been invited to
+   * this position, then updates the application status message and whether they
+   * can apply.
+   * @param jobIndex Index of the position
+   * @returns Void
+   */
+  const checkApplied = async (jobIndex: number): Promise<void> => {
+    // check if user is logged in
+    if (!currentUserId) {
+      return;
+    }
     try {
       // if an error is thrown -> no request found
       const result = await getMemberRequest({
@@ -210,7 +219,15 @@ export const TeamPositionsPanel = ({ currentUserId, displayedProject, viewedPosi
                   if (quickApplyOpen) {
                     handleQuickApply();
                   } else {
-                    setQuickApplyOpen(true);
+                    // if not logged in, send to login page
+                    if (!currentUserId) {
+                      navigate(paths.routes.LOGIN, {
+                        state: { from: location }
+                      });
+                    // otherwise, show quick apply fields 
+                    } else {
+                      setQuickApplyOpen(true);
+                    }
                   }
                 }}
               >

--- a/server/src/services/projects/members/request-to-join.ts
+++ b/server/src/services/projects/members/request-to-join.ts
@@ -14,7 +14,7 @@ import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service
 import getProjectByIdService from '../get-proj-id.ts';
 
 type RequestToJoinServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND' | 'CONFLICT'>;
-type RequestToJoinServiceSuccess = ServiceSuccessSubset<'OK'>;
+type RequestToJoinServiceSuccess = ServiceSuccessSubset<'NO_CONTENT'>;
 
 // POST api/projects/:id/members/request-to-join
 export const requestToJoinService = async (
@@ -146,9 +146,22 @@ export const requestToJoinService = async (
 
     //send email
     const emailResult = await sendEmail(email);
-    if (emailResult === 'INTERNAL_ERROR') return emailResult;
+    if (emailResult === 'INTERNAL_ERROR') {
+      // failed to send email -> rollback request
+      try {
+        await prisma.memberRequests.delete({
+          where: {
+            requestId: result.requestId,
+          },
+        });
+      } catch (rollbackError) {
+        console.error('Failed to rollback member request:', rollbackError);
+      }
 
-    return 'OK';
+      return emailResult;
+    }
+
+    return 'NO_CONTENT';
   } catch (e) {
     console.error(`There was an error in requestToJoinService: `, e);
     return 'INTERNAL_ERROR';

--- a/server/src/services/projects/members/send-invite.ts
+++ b/server/src/services/projects/members/send-invite.ts
@@ -10,7 +10,7 @@ import { UserEmailSelector } from '#services/selectors/users/parts/user-email.ts
 import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service-outcomes.ts';
 
 type SendInviteServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND' | 'CONFLICT'>;
-type SendInviteServiceSuccess = ServiceSuccessSubset<'OK'>;
+type SendInviteServiceSuccess = ServiceSuccessSubset<'NO_CONTENT'>;
 
 // POST api/projects/:id/members/send-invite
 // Sends an invite to a user to join a project
@@ -127,10 +127,21 @@ const sendInviteService = async (
 
     const emailResult = await sendEmail(email);
     if (emailResult === 'INTERNAL_ERROR') {
+      // failed to send email -> rollback request
+      try {
+        await prisma.memberRequests.delete({
+          where: {
+            requestId: result.requestId,
+          },
+        });
+      } catch (rollbackError) {
+        console.error('Failed to rollback member request:', rollbackError);
+      }
+
       return emailResult;
     }
 
-    return 'OK';
+    return 'NO_CONTENT';
   } catch (e) {
     if (e instanceof Object && 'code' in e) {
       if (e.code === 'P2025') {

--- a/server/tests/projectstest/get-paginated-projects.test.ts
+++ b/server/tests/projectstest/get-paginated-projects.test.ts
@@ -56,14 +56,14 @@ const prismaProjects: Projects[] = [
 
 const mockPreviews = [
   {
-    projectId: 200,
-    ownerId: 2,
-    title: 'Alpha test',
-  },
-  {
     projectId: 100,
     ownerId: 1,
     title: 'Beta test',
+  },
+  {
+    projectId: 200,
+    ownerId: 2,
+    title: 'Alpha test',
   },
 ];
 
@@ -93,7 +93,7 @@ describe('getPaginatedProjectsService', async () => {
       expect.objectContaining({
         take: 2,
         orderBy: {
-          createdAt: 'desc',
+          projectId: 'asc' as const,
         },
         where: {
           approved: true,
@@ -120,7 +120,7 @@ describe('getPaginatedProjectsService', async () => {
           projectId: 100,
         },
         orderBy: {
-          createdAt: 'desc',
+          projectId: 'asc' as const,
         },
         where: {
           approved: true,

--- a/server/tests/projectstest/members/request-to-join.test.ts
+++ b/server/tests/projectstest/members/request-to-join.test.ts
@@ -75,7 +75,7 @@ describe('requestToJoinService', async () => {
     vi.clearAllMocks();
   });
 
-  it('returns OK when successful', async () => {
+  it('returns NO_CONTENT when successful', async () => {
     vi.mocked(prisma.memberRequests.findFirst).mockResolvedValue(null);
     vi.mocked(getRolesService).mockResolvedValue(exampleRoles);
     vi.mocked(prisma.users.findUnique).mockResolvedValueOnce({ userId: 10 } as Users);
@@ -85,7 +85,7 @@ describe('requestToJoinService', async () => {
     vi.mocked(prisma.memberRequests.create).mockResolvedValue(prismaApplicationRequest);
 
     const result = await requestToJoinService(100, requestData);
-    expect(result).toBe('OK');
+    expect(result).toBe('NO_CONTENT');
   });
 
   it('returns CONFLICT when the request already exists', async () => {

--- a/server/tests/projectstest/members/send-invite.test.ts
+++ b/server/tests/projectstest/members/send-invite.test.ts
@@ -75,7 +75,7 @@ describe('requestToJoinService', async () => {
     vi.clearAllMocks();
   });
 
-  it('returns OK when successful', async () => {
+  it('returns NO_CONTENT when successful', async () => {
     vi.mocked(prisma.memberRequests.findFirst).mockResolvedValue(null);
     vi.mocked(getRolesService).mockResolvedValue(exampleRoles);
     vi.mocked(prisma.users.findUnique).mockResolvedValueOnce({ userId: 10 } as Users);
@@ -85,7 +85,7 @@ describe('requestToJoinService', async () => {
     vi.mocked(prisma.memberRequests.create).mockResolvedValue(prismaApplicationRequest);
 
     const result = await sendInviteService(100, requestData);
-    expect(result).toBe('OK');
+    expect(result).toBe('NO_CONTENT');
   });
 
   it('returns CONFLICT when the request already exists', async () => {


### PR DESCRIPTION
Before, the service would return an `INTERNAL_ERROR` when emails were not sent out correctly, but the request would remain in the table.
Now, when an email fails to be sent, the service will roll back the request from the table.
Also, update the logic in the open positions panel to send guests to the login page when they click on "Quick Apply"

(Note: When you test anything related to invite/request on your local machine, you need to install [mailpit](https://mailpit.axllent.org) for SMTP; otherwise, you will get an error like this:
```
[0] Verification failed: Error: connect ECONNREFUSED ::1:1025
[0]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1705:16) {
[0]   errno: -61,
[0]   code: 'ESOCKET',
[0]   syscall: 'connect',
[0]   address: '::1',
[0]   port: 1025,
[0]   command: 'CONN'
[0] }
[0] POST /api/projects/1/members/request-to-join 500 260.979 ms - 58
```