### PR TITLE
Add backend support for different sorting methods for projects/users

### DIFF
--- a/client/src/api/users.ts
+++ b/client/src/api/users.ts
@@ -100,7 +100,9 @@ export const getCurrentUsername = async (): Promise<UsernameResponse> => {
  * @returns result - JSONified data of all users, else if error, '400'.
  */
 export const getUsers = async (): Promise<ApiResponse<UserPreview[]>> => {
-  const apiURL = `/users`;
+  //NOTE: the "A-Z" is a default implementation of sorting method
+  //CHANGE THIS WHEN SORTING METHOD FRONTEND IS IMPLEMENTED!!
+  const apiURL = `/users/A-Z`;
   const response = await GET(apiURL);
   //TODO: revisit this to make it include filters
   //but filters are a stretch goal anyway so it's not too important

--- a/client/src/components/pages/Discover.tsx
+++ b/client/src/components/pages/Discover.tsx
@@ -160,7 +160,9 @@ export const DiscoverPage = () => {
 
   //Gets the projects and updates the variables above
   const getPaginatedProjects = async () => {
-    let returnedProjects = await GET(`/projects/paginated/${count}/${index}`);
+    //NOTE: the "Newest" here is a default implementation for sorting method, so the site doesn't break
+    //CHANGE THIS WHEN FRONT END IS ACTUALLY IMPLEMENTED!!
+    let returnedProjects = await GET(`/projects/paginated/${count}/${index}/Newest`);
 
     if (returnedProjects.data && returnedProjects.data[returnedProjects.data.length - 1]) {
       index = returnedProjects.data[returnedProjects.data.length - 1].projectId;

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -171,12 +171,18 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   # USERS
-  /api/users:
+  /api/users/{method}:
     get:
       summary: Get all users
       tags:
         - Users
       parameters:
+        - in: path
+          name: method
+          required: true
+          schema:
+            type: string
+          description: Sorting method (options are "Newest" for newest first and "A-Z" for alphabetical)
         - in: query
           name: strictness
           required: false
@@ -243,6 +249,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  /api/users:
     post:
       summary: Create a user
       tags:

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -1757,7 +1757,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /api/projects/paginated/{count}/{id}:
+  /api/projects/paginated/{count}/{id}/{method}:
     get:
       summary: Get paginated projects
       tags:
@@ -1776,6 +1776,12 @@ paths:
           schema:
             type: integer
           description: The project ID cursor. Projects after this ID will be returned. Use 0 to start from the beginning.
+        - in: path
+          name: method
+          required: true
+          schema:
+            type: string
+          description: Sorting method (options are "Newest" for newest first and "A-Z" for alphabetical)
       responses:
         '200':
           description: A list of projects

--- a/server/src/api/controllers/projects/get-paginated-projects.ts
+++ b/server/src/api/controllers/projects/get-paginated-projects.ts
@@ -1,8 +1,8 @@
-import type { ApiResponse, ProjectPreview } from '@looking-for-group/shared';
+import type { ApiResponse, ProjectPreview, ProjectSortMethod } from '@looking-for-group/shared';
 import type { Request, Response } from 'express';
 import getService from '#services/projects/get-paginated-projects.ts';
 
-//GET api/projects/paginated/:count/:id
+//GET api/projects/paginated/:count/:id/:method
 //gets 10 projects
 const getPaginatedProjectsController = async (
   req: Request,
@@ -10,7 +10,8 @@ const getPaginatedProjectsController = async (
 ): Promise<ApiResponse<ProjectPreview[]> | undefined> => {
   const count = parseInt(req.params.count as string);
   const projectId = parseInt(req.params.id as string);
-  const result = await getService(count, projectId);
+  const method = req.params.method as ProjectSortMethod;
+  const result = await getService(count, projectId, method);
 
   if (result === 'INTERNAL_ERROR') {
     const resBody: ApiResponse = {

--- a/server/src/api/controllers/users/get-all.ts
+++ b/server/src/api/controllers/users/get-all.ts
@@ -1,4 +1,9 @@
-import type { RitStatus, ApiResponse, FilterRequest } from '@looking-for-group/shared';
+import type {
+  RitStatus,
+  ApiResponse,
+  FilterRequest,
+  UserSortMethod,
+} from '@looking-for-group/shared';
 import type { Request, Response } from 'express';
 import { UsersRitStatus } from '#prisma-models/index.js';
 import { getAllUsersService } from '#services/users/get-all-users.ts';
@@ -104,8 +109,10 @@ export const getAllUsers = async (req: Request, res: Response): Promise<void> =>
     }
   }
 
+  //Add sort method
+  const sortMethod = req.params.method as UserSortMethod;
   //send it over
-  const result = await getAllUsersService(filters);
+  const result = await getAllUsersService(filters, sortMethod);
 
   if (result === 'INTERNAL_ERROR') {
     const resBody: ApiResponse = {

--- a/server/src/api/routes/projects.ts
+++ b/server/src/api/routes/projects.ts
@@ -51,7 +51,7 @@ router.patch(
 router.get('/', PROJECT.getProjects);
 
 //Receive paginated projects
-router.get('/paginated/:count/:id', PROJECT.getPaginatedProjects);
+router.get('/paginated/:count/:id/:method', PROJECT.getPaginatedProjects);
 
 //Create a new project
 router.post('/', requiresLogin, injectCurrentUser, authenticated(PROJECT.createProject));

--- a/server/src/api/routes/users.ts
+++ b/server/src/api/routes/users.ts
@@ -16,7 +16,7 @@ import { userExistsAt } from '../middleware/validators/user-exists-at.ts';
 const router = Router();
 
 //Gets users
-router.get('/', getAllUsers);
+router.get('/:method', getAllUsers);
 
 //Creates a new user
 router.post('/', createUser);

--- a/server/src/services/projects/get-paginated-projects.ts
+++ b/server/src/services/projects/get-paginated-projects.ts
@@ -1,4 +1,4 @@
-import type { ProjectPreview } from '@looking-for-group/shared';
+import type { ProjectPreview, ProjectSortMethod } from '@looking-for-group/shared';
 import prisma from '#config/prisma.ts';
 import { ProjectPreviewSelector } from '#services/selectors/projects/project-preview.ts';
 import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
@@ -10,6 +10,7 @@ type GetServiceError = ServiceErrorSubset<'INTERNAL_ERROR'>;
 const getPaginatedProjectsService = async (
   count: number,
   lastProjectId: number,
+  sortMethod: ProjectSortMethod,
 ): Promise<ProjectPreview[] | GetServiceError> => {
   try {
     //There should be a better way of doing this
@@ -23,12 +24,21 @@ const getPaginatedProjectsService = async (
     //   count = remainingProjects;
     // }
 
+    //set up sorting option
+    let orderByInput;
+    switch (sortMethod) {
+      case 'Newest':
+        orderByInput = { createdAt: 'desc' as const };
+        break;
+      case 'A-Z':
+        orderByInput = { title: 'asc' as const };
+        break;
+    }
+
     const query = {
       select: ProjectPreviewSelector,
       take: count,
-      orderBy: {
-        projectId: 'asc' as const,
-      },
+      orderBy: orderByInput,
       where: {
         approved: true,
       },

--- a/server/src/services/users/get-all-users.ts
+++ b/server/src/services/users/get-all-users.ts
@@ -1,4 +1,4 @@
-import type { FilterRequest, UserPreview } from '@looking-for-group/shared';
+import type { FilterRequest, UserPreview, UserSortMethod } from '@looking-for-group/shared';
 import prisma from '#config/prisma.ts';
 import { UserDetailSelector } from '#services/selectors/users/user-detail.ts';
 import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
@@ -8,6 +8,7 @@ type GetUserServiceError = ServiceErrorSubset<'INTERNAL_ERROR'>;
 
 export const getAllUsersService = async (
   filters: FilterRequest,
+  sortMethod: UserSortMethod,
 ): Promise<UserPreview[] | GetUserServiceError> => {
   try {
     const parsedFilters = [] as object[];
@@ -108,19 +109,23 @@ export const getAllUsersService = async (
       restrictionObject = { AND: parsedFilters };
     }
 
+    let orderByInput;
+    switch (sortMethod) {
+      case 'Newest':
+        orderByInput = { createdAt: 'desc' as const };
+        break;
+      case 'A-Z':
+        orderByInput = { firstName: 'asc' as const };
+        break;
+    }
+
     const users = await prisma.users.findMany({
       where: restrictionObject,
-      orderBy: { createdAt: 'desc' },
+      orderBy: orderByInput,
       select: UserDetailSelector,
     });
 
-    let transformedUsers = users.map(transformUserToPreview);
-
-    //Sorts the users in alphabetical order by first name
-    transformedUsers = transformedUsers.toSorted(
-      (transformedUser1, transformedUser2) =>
-        transformedUser1.firstName.charCodeAt(0) - transformedUser2.firstName.charCodeAt(0),
-    );
+    const transformedUsers = users.map(transformUserToPreview);
 
     //For when the preferred name column is implemented in the database
     // transformedUsers = transformedUsers.toSorted((transformedUser1, transformedUser2) =>

--- a/server/tests/projectstest/get-paginated-projects.test.ts
+++ b/server/tests/projectstest/get-paginated-projects.test.ts
@@ -87,13 +87,13 @@ describe('getPaginatedProjectsService', async () => {
   it('Returns first 2 projects', async () => {
     (prisma.projects.findMany as Mock).mockResolvedValue(prismaProjects);
 
-    const result = await getPaginatedProjectsService(2, 0);
+    const result = await getPaginatedProjectsService(2, 0, 'Newest');
 
     expect(prisma.projects.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         take: 2,
         orderBy: {
-          projectId: 'asc' as const,
+          createdAt: 'desc' as const,
         },
         where: {
           approved: true,
@@ -110,7 +110,7 @@ describe('getPaginatedProjectsService', async () => {
   it('Uses cursor pagination when lastProjectId is provided', async () => {
     (prisma.projects.findMany as Mock).mockResolvedValue(prismaProjects);
 
-    await getPaginatedProjectsService(2, 100);
+    await getPaginatedProjectsService(2, 100, 'Newest');
 
     expect(prisma.projects.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -120,7 +120,7 @@ describe('getPaginatedProjectsService', async () => {
           projectId: 100,
         },
         orderBy: {
-          projectId: 'asc' as const,
+          createdAt: 'desc' as const,
         },
         where: {
           approved: true,
@@ -132,7 +132,7 @@ describe('getPaginatedProjectsService', async () => {
   it('Returns fewer projects than requested when fewer are available', async () => {
     (prisma.projects.findMany as Mock).mockResolvedValue([prismaProjects[0]]);
 
-    const result = await getPaginatedProjectsService(10, 0);
+    const result = await getPaginatedProjectsService(10, 0, 'Newest');
 
     expect(transformProjectToPreview).toHaveBeenCalledTimes(1);
     expect(result).toEqual([
@@ -148,7 +148,7 @@ describe('getPaginatedProjectsService', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     (prisma.projects.findMany as Mock).mockRejectedValue(new Error('db on fire'));
 
-    const result = await getPaginatedProjectsService(2, 0);
+    const result = await getPaginatedProjectsService(2, 0, 'Newest');
 
     expect(result).toBe('INTERNAL_ERROR');
     expect(transformProjectToPreview).not.toHaveBeenCalled();

--- a/server/tests/userstest/get-all-users.int.test.ts
+++ b/server/tests/userstest/get-all-users.int.test.ts
@@ -5,7 +5,7 @@ import { expect, it } from 'vitest';
 import { getAllUsersService } from '#services/users/get-all-users.ts';
 
 it('DEBUG: prints all users NO MOCKS! IF this doesnt work, database error.', async () => {
-  const result = await getAllUsersService({});
+  const result = await getAllUsersService({}, 'A-Z');
 
   //console.log('USERS FROM SERVICE:',result);
   expect(result.length).toBeGreaterThan(0);
@@ -14,7 +14,7 @@ it('DEBUG: prints all users NO MOCKS! IF this doesnt work, database error.', asy
 
 //test for each field we need.
 it('DEBUG: returns required preview fields, if we change user fields change this!', async () => {
-  const result = await getAllUsersService({});
+  const result = await getAllUsersService({}, 'A-Z');
 
   expect(Array.isArray(result)).toBe(true);
   expect(result.length).toBeGreaterThan(0);

--- a/server/tests/userstest/get-all-users.test.ts
+++ b/server/tests/userstest/get-all-users.test.ts
@@ -77,7 +77,7 @@ describe('test getAllUsersService', () => {
   it('returns all users when no filters are provided', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    const result = await getAllUsersService({});
+    const result = await getAllUsersService({}, 'A-Z');
     //console.log(result);
     expect(vi.mocked(prisma.users.findMany)).toHaveBeenCalled();
     expect(result).toEqual(mockPreviews);
@@ -86,10 +86,13 @@ describe('test getAllUsersService', () => {
   it('applies mentor filter', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    await getAllUsersService({
-      mentor: true,
-      strictness: 'all',
-    });
+    await getAllUsersService(
+      {
+        mentor: true,
+        strictness: 'all',
+      },
+      'A-Z',
+    );
 
     // console.log(result);
     const findMany = prisma.users.findMany;
@@ -106,10 +109,13 @@ describe('test getAllUsersService', () => {
   it('applies designer filter', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    await getAllUsersService({
-      designer: true,
-      strictness: 'all',
-    });
+    await getAllUsersService(
+      {
+        designer: true,
+        strictness: 'all',
+      },
+      'A-Z',
+    );
 
     const findMany = prisma.users.findMany;
     expect(findMany).toHaveBeenCalled();
@@ -134,10 +140,13 @@ describe('test getAllUsersService', () => {
   it('applies designer=false filter', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    await getAllUsersService({
-      developer: false,
-      strictness: 'all',
-    });
+    await getAllUsersService(
+      {
+        developer: false,
+        strictness: 'all',
+      },
+      'A-Z',
+    );
 
     expect(prisma.users.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -159,12 +168,15 @@ describe('test getAllUsersService', () => {
   it('applies skills + majors + socials filters', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    await getAllUsersService({
-      skills: [1, 2],
-      majors: [3],
-      socials: [4],
-      strictness: 'all',
-    });
+    await getAllUsersService(
+      {
+        skills: [1, 2],
+        majors: [3],
+        socials: [4],
+        strictness: 'all',
+      },
+      'A-Z',
+    );
 
     expect(prisma.users.findMany).toHaveBeenCalled();
     expect(prisma.users.findMany).toHaveBeenCalledWith(
@@ -201,11 +213,14 @@ describe('test getAllUsersService', () => {
   it('uses OR when strictness = any', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    await getAllUsersService({
-      mentor: true,
-      developer: true,
-      strictness: 'any',
-    });
+    await getAllUsersService(
+      {
+        mentor: true,
+        developer: true,
+        strictness: 'any',
+      },
+      'A-Z',
+    );
 
     expect(prisma.users.findMany).toHaveBeenCalled();
     expect(prisma.users.findMany).toHaveBeenCalledWith(
@@ -229,7 +244,7 @@ describe('test getAllUsersService', () => {
   it('returns INTERNAL_ERROR on exception', async () => {
     (prisma.users.findMany as Mock).mockRejectedValue(new Error('db exploded :fire:'));
 
-    const result = await getAllUsersService({ strictness: 'any' });
+    const result = await getAllUsersService({ strictness: 'any' }, 'A-Z');
 
     expect(result).toBe('INTERNAL_ERROR');
   });
@@ -237,7 +252,7 @@ describe('test getAllUsersService', () => {
   it('transforms users before returning', async () => {
     (prisma.users.findMany as Mock).mockResolvedValue(mockUsers);
 
-    const result = await getAllUsersService({ strictness: 'any' });
+    const result = await getAllUsersService({ strictness: 'any' }, 'A-Z');
 
     expect(transformUserToPreview).toHaveBeenCalledTimes(2);
     expect(result).toEqual(mockPreviews);

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -53,6 +53,7 @@ export type JobLocation = "OnSite" | "Remote" | "Hybrid";
 export type JobCompensation = "Unpaid" | "Paid";
 export type MemberRequestStatus = "Accepted" | "Declined" | "Pending";
 export type ProjectSortMethod = "Newest" | "A-Z";
+export type UserSortMethod = "Newest" | "A-Z";
 export type Visibility = "public" | "private";
 //do we even need this visibility enum at all? it's stored as a 0/1 in the db anyway
 //a problem for another day, i really don't feel like fixing it right now

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -52,6 +52,7 @@ export type JobDuration = "Days" | "Weeks" | "Months" | "Semesters" | "Years";
 export type JobLocation = "OnSite" | "Remote" | "Hybrid";
 export type JobCompensation = "Unpaid" | "Paid";
 export type MemberRequestStatus = "Accepted" | "Declined" | "Pending";
+export type ProjectSortMethod = "Newest" | "A-Z";
 export type Visibility = "public" | "private";
 //do we even need this visibility enum at all? it's stored as a 0/1 in the db anyway
 //a problem for another day, i really don't feel like fixing it right now


### PR DESCRIPTION
Currently, I have implemented newest first and A-Z sorting methods for getting projects and users.