### PR TITLE
Tab colors cleanup

### DIFF
--- a/client/src/components/ProjectCreatorEditor/tabs/TagsTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/TagsTab.tsx
@@ -22,7 +22,7 @@ const tagTabColors: Record<string, string> = {
   Medium: 'blue',
   Genre: 'green',
   Style: 'pink',
-  'Game Engine': 'orange',
+  'Game Engine': 'yellow',
 };
 
 let projectAfterTagsChanges: PendingProject;

--- a/client/src/components/SignupProcess/ChooseSkills.tsx
+++ b/client/src/components/SignupProcess/ChooseSkills.tsx
@@ -16,7 +16,7 @@ const skillTabColors: Record<string, string> = {
   Design: "red",
   Soft: "purple",
   Audio: "periwinkle",
-  Engineer: "purple",
+  Engineer: "cyan",
 };
 
 // list of skills to choose from


### PR DESCRIPTION
I fixed the tab color for Game Engine in TagsTab to be yellow, and the Engineer tab in ChooseSkills to cyan, the new engineer color.