### PR TITLE
fix: resolve background scroll bleeding on iOS and iPad Safari

### DIFF
--- a/client/src/components/PagePopup.tsx
+++ b/client/src/components/PagePopup.tsx
@@ -1,4 +1,4 @@
-import { Dispatch,ReactNode, SetStateAction } from 'react';
+import { Dispatch,ReactNode, SetStateAction, useEffect } from 'react';
 
 //This component is meant to be reusable in any area of the site, acting as an element that can be
 //  opened or closed after performing certain actions.
@@ -87,6 +87,20 @@ export const PagePopup = ({
   setShow,
   onClose = () => {},
 }: PagePopupProps) => {
+
+  // Lock body scroll when popup is open
+  useEffect(() => {
+    if (show) {
+      document.body.classList.add('modal-open');
+    } else {
+      document.body.classList.remove('modal-open');
+    }
+
+    return () => {
+      document.body.classList.remove('modal-open');
+    };
+  }, [show]);
+
   if (!show) return null;
 
   return (

--- a/client/src/components/Popup.tsx
+++ b/client/src/components/Popup.tsx
@@ -181,6 +181,20 @@ export const PopupContent = ({
     return () => window.removeEventListener('popstate', handlePopState);
   }, [closePopup, open]);
 
+  // Lock body scroll when popup is open
+  useEffect(() => {
+    if (open) {
+      document.body.classList.add('modal-open');
+    } else {
+      document.body.classList.remove('modal-open');
+    }
+    
+    // Cleanup class if the component unmounts unexpectedly
+    return () => {
+      document.body.classList.remove('modal-open');
+    };
+  }, [open]);
+
   return (
     <>
       {/* {document.getElementsByClassName("popup-cover").length < 1 ? <div className="popup-cover" /> : <></>} */}

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -321,6 +321,7 @@ section {
   margin: 30px auto;
 }
 
+
 /* #endregion */
 
 /*
@@ -1036,6 +1037,12 @@ Page popup style rules
   height: 100%;
   z-index: 5;
   border-radius: 10px;
+}
+
+html.modal-open,
+body.modal-open {
+  overflow: hidden !important;
+  height: 100% !important;
 }
 
 @media only screen and (hover: none) {


### PR DESCRIPTION
I locked scrolling on page(behind popup) while popups are open as well as putting in place ways to prevent scroll bleeding for IOS and Safari.