### PR TITLE
Trimmed Input : Update Input.tsx

### DIFF
--- a/client/src/components/Input.tsx
+++ b/client/src/components/Input.tsx
@@ -37,10 +37,20 @@ export const Input: React.FC<CustomInputProps> = ({
 
     // Handle prop changes
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const trimmedValue = e.target.value
+      // .replace(/ {2,}/g, " ")
+      .replace(/ +$/g, " ")   // remove trailing spaces
+      .replace(/^ +/g, "")   // remove leading spaces
+
+
       if (onChange) {
-        onChange(e);
+        onChange({
+          ...e,
+          target: {...e.target, value: trimmedValue }
+        });
       }
-      setInternalValue(e.target.value);
+
+      setInternalValue(trimmedValue);
     };
 
     return (
@@ -60,12 +70,27 @@ export const Input: React.FC<CustomInputProps> = ({
     );
   }
 
-  // Standard Input (single line)
+  // Standard Input
+  const doSingleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const trimmedValue = e.target.value
+    // .replace(/ {2,}/g, " ")
+    .replace(/ +$/g, "")
+    .replace(/^ +/g, " ");
+
+
+    if (onChange) {
+      onChange({
+        ...e,
+        target: {...e.target, value: trimmedValue }
+      });
+    }
+  };
+
   return (
     <input
       className="input"
       maxLength={props.maxLength}
-      onChange={onChange as React.ChangeEventHandler<HTMLInputElement>}
+      onChange={doSingleChange}
       placeholder={placeholder}
       {...props}
     />


### PR DESCRIPTION
No leading spaces, allows only 1 trailing spaces, so users cant put space and it counts as a character in the beginning, next line does work. 
The only way to add multiple space in something is to click in between a word and add it there otherwise no double spaces would be allowed. 
Able to select word by click twice, a line by clicking thrice.