### PR TITLE
Changed the layout

### DIFF
--- a/client/src/components/Styles/aboutTab.css
+++ b/client/src/components/Styles/aboutTab.css
@@ -27,7 +27,7 @@
   /* height: 100%; */
 
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   column-gap: 10px;
 }
 
@@ -150,8 +150,6 @@ select {
   }
 
   #edit-profile-section-2 {
-    display: flex !important;
-    flex-direction: row;
     gap: 20px;
     align-items: center;
     width: 100%;


### PR DESCRIPTION
Even though the about on the same line as Quote would be preferred, it causes blank space and if we fixed that then the quote section is far too big for the 100 limit.

Tried another thing like moving location down to be on the same line as Quote, but it messes up with Mentorship as it's far too long. I think this is the best choice? At least for now.