### PR TITLE
fix space when profile bio has no content

### DIFF
--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -558,7 +558,7 @@ const Profile = (userProfile: any) => {
                   profileImg.src = profilePicture;
                 }}
               />
-              <div id="profile-bio">{displayedProfile?.headline}</div>
+              {displayedProfile?.headline != "" ? <div id="profile-bio">{displayedProfile?.headline}</div> : ""}
             </div>
 
             <div id="profile-info">


### PR DESCRIPTION
Spacing looks better on profile

before
<img width="281" height="363" alt="image" src="https://github.com/user-attachments/assets/42ad4a7a-678d-4b35-a03b-6b9a81076697" />


after
<img width="491" height="626" alt="image" src="https://github.com/user-attachments/assets/a7f0650f-391f-40cc-b5a5-ad2cccbbeafe" />

Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/1921
