### PR TITLE
Get user's access level endpoint

### DIFF
--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -5009,6 +5009,41 @@ paths:
                     example: Skill deleted successfully
         '500':
           $ref: '#components/responses/InternalServerError'
+  /api/admin/status/{id}:
+    get:
+      summary: Gets the access level of a user
+      tags:
+        - Admin
+      description: Gets the access level of a given user (current user only right now)
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: The ID of the user to get their access level from.
+      responses:
+        '200':
+          description: Access level successfully returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  error:
+                    nullable: true
+                    example: null
+                  data:
+                    example: 'User'
+        '400':
+          $ref: '#components/responses/BadRequest'
+        '404':
+          $ref: '#components/responses/NotFound'
+        '500':
+          $ref: '#components/responses/InternalServerError'
 
 # COMPONENTS
 components:

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -5014,7 +5014,7 @@ paths:
       summary: Gets the access level of a user
       tags:
         - Admin
-      description: Gets the access level of a given user (current user only right now)
+      description: Gets the access level of a given user
       parameters:
         - in: path
           name: id

--- a/server/src/api/controllers/admin/get-mod-status.ts
+++ b/server/src/api/controllers/admin/get-mod-status.ts
@@ -1,0 +1,40 @@
+import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { Response } from 'express';
+import { getAccessLevelService } from '#services/admin/get-mod-status.ts';
+
+//GET api/admin/status/:id
+//get a user's access level (current user only currently)
+export const getAccessLevel = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  const id: number = parseInt(req.params.id as string);
+  const result = await getAccessLevelService(id);
+
+  if (result === 'INTERNAL_ERROR') {
+    const resBody: ApiResponse = {
+      status: 500,
+      error: 'Internal Server Error',
+      data: null,
+    };
+
+    res.status(500).json(resBody);
+    return;
+  }
+
+  if (result === 'NOT_FOUND') {
+    const resBody: ApiResponse = {
+      status: 404,
+      error: 'User not found',
+      data: null,
+    };
+
+    res.status(404).json(resBody);
+    return;
+  }
+
+  const resBody: ApiResponse<typeof result> = {
+    status: 200,
+    error: null,
+    data: result,
+  };
+
+  res.status(200).json(resBody);
+};

--- a/server/src/api/routes/admin.ts
+++ b/server/src/api/routes/admin.ts
@@ -6,6 +6,7 @@ import deleteTag from '#controllers/admin/delete-tag.ts';
 import demoteMod from '#controllers/admin/demote-from-mod.ts';
 import editSkill from '#controllers/admin/edit-skill.ts';
 import editTag from '#controllers/admin/edit-tag.ts';
+import { getAccessLevel } from '#controllers/admin/get-mod-status.ts';
 import promoteUserToMod from '#controllers/admin/promote-to-mod.ts';
 import requiresAdmin from '#middleware/authorization/requires-admin.ts';
 import requiresLogin from '#middleware/authorization/requires-login.ts';
@@ -16,6 +17,8 @@ import { userExistsAt } from '#middleware/validators/user-exists-at.ts';
 import { authenticated } from './me.ts';
 
 const router = Router();
+
+router.get('/status/:id', requiresLogin, authenticated(getAccessLevel));
 
 router.use(requiresLogin, injectCurrentUser, authenticated(requiresAdmin));
 

--- a/server/src/services/admin/get-mod-status.ts
+++ b/server/src/services/admin/get-mod-status.ts
@@ -1,0 +1,18 @@
+import type { UserAccessLevel } from '@looking-for-group/shared';
+import { getUserAccessLevel } from '#services/authentication/get-user-access-level.ts';
+import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
+
+type GetUserServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND'>;
+
+//GET api/admin/status/:id
+export const getAccessLevelService = async (
+  userId: number,
+): Promise<UserAccessLevel | GetUserServiceError> => {
+  try {
+    const accessLevel = await getUserAccessLevel(userId);
+    return accessLevel;
+  } catch (e) {
+    console.error('Error in getUserByIdService:', e);
+    return 'INTERNAL_ERROR';
+  }
+};


### PR DESCRIPTION
Created an endpoint to get a user's access level. Getting the current user wasn't working, but the current user's userId can be passed in

Closes https://github.com/orgs/LookingforGrp-rit/projects/7/views/1?pane=issue&itemId=211452217&issue=LookingforGrp-rit%7CLookingForGroup%7C1916