### PR TITLE
More Filters text is not displayed in mobile views anymore, just a button with the icon

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -782,6 +782,18 @@ Filters / Tags Style Rules
   justify-content: center;
 }
 
+@media screen and (max-width: 799px) {
+  #discover-more-filters {
+    width: 70px;
+
+    #more-filters-button {
+      #more-filters-text {
+        display: none;
+      }
+    }
+  }
+}
+
 .applied-filters {
   width: auto;
   margin: 20px 50px;


### PR DESCRIPTION
Desktop view is unaffected. This is to make using the medium filter buttons more usable with the arrow buttons scrolling through them.