### PR TITLE
fixed middleware using for reporting user

### DIFF
--- a/server/src/api/routes/me.ts
+++ b/server/src/api/routes/me.ts
@@ -169,7 +169,7 @@ router.get('/get-username', authenticated(getUsernameByGoogle));
 //Report user
 router.post(
   '/users/report/:id/:report',
-  projectExistsAt('path', 'id'),
+  userExistsAt('path', 'id'),
   authenticated(reportUserController),
 );
 


### PR DESCRIPTION
not a documented issue. see send-help in discord for context.
report user endpoint was using the middleware to check if a project exists hence 404 - project not found.