### PR TITLE
fixed template profile page display

### DIFF
--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -257,6 +257,8 @@ const Profile = (userProfile: any) => {
         setMajorsArr(data.majors.map((maj) => maj.label));
         await getProfileProjectData();
         //checkFollow();
+      } else {
+        navigate(paths.routes.NOTFOUND, { replace: true });
       }
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
redirects to notfound when an invalid userid is input in the query.