### PR TITLE
Added required field indicators to the invite member popup

### DIFF
--- a/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
@@ -104,7 +104,8 @@ type TeamTabProps = {
 		invitations: MemberRequests[];
 		applications: MemberRequests[];
 	}>>;
-	//setProjectData: (data: ProjectDetail) => void; because of the data manager we no longer directly update the projectData from here
+	//setProjectData: (data: ProjectDetail) => void; because of the data manager we no longer directly update the projectData 
+	// from here
 	setErrorMember: (error: string) => void;
 	setErrorPosition: (error: string) => void;
 	// permissions: number;
@@ -2318,7 +2319,7 @@ export const TeamTab = ({
 						</div>
 						<div id="project-team-add-member-info">
 							<label id="project-team-add-member-name">
-								Name
+								Name <span className="requiredAsterisk">*</span>
 							</label>
 							<div id="user-search-container">
 								<Dropdown>
@@ -2368,7 +2369,7 @@ export const TeamTab = ({
 								</Dropdown>
 							</div>
 							<label id="project-team-add-member-role">
-								Role
+								Role <span className="requiredAsterisk">*</span>
 							</label>
 							<Select key={selectKey}>
 								<SelectButton
@@ -2410,6 +2411,9 @@ export const TeamTab = ({
 								onChange={(e) =>
 									setMessageText(e.target.value)
 								}></textarea>
+						</div>
+						<div className="requiredText">
+							<span className="requiredAsterisk">*</span> Indicates required field
 						</div>
 						{/* Action buttons */}
 						<div className="project-editor-button-pair">

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -139,7 +139,7 @@ General style rules
     Should be black for all tags in light mode
     and match the tag color in dark mode
     */
-    
+
 }
 
 /*light mode color scheme*/
@@ -1413,6 +1413,15 @@ body.modal-open {
   #filter-tabs {
     column-gap: min(6vw, 45px);
   }
+}
+
+/* Styles for required fields */
+.requiredAsterisk {
+  color: red;
+}
+
+.requiredText {
+  font-style: italic;
 }
 
 /* Mobile styling */


### PR DESCRIPTION
The styles I used are on client/src/components/Styles/general.css line 1418 if anyone wants to move/change them.

Closes https://github.com/orgs/LookingforGrp-rit/projects/7/views/1?pane=issue&itemId=213023203&issue=LookingforGrp-rit%7CLookingForGroup%7C1986