### PR TITLE
Light/Dark Mode

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -866,7 +866,7 @@ Filters / Tags Style Rules
   p {
     margin: 0px;
     border: 0px;
-    color: var(--tag-text-selected);
+    color: var(--main-text);
   }
 
   i {
@@ -878,6 +878,22 @@ Filters / Tags Style Rules
   }
 }
 
+/* Light-colored background tags will have dark text color */
+.tag-yellow p,
+.tag-periwinkle p,
+.tag-cyan p {
+  color: black !important;
+}
+
+/* Dark-colored background tags follow theme text color */
+.tag-blue p,
+.tag-green p,
+.tag-red p,
+.tag-purple p,
+.tag-pink p,
+.tag-grey p {
+  color: var(--main-text) !important;
+}
 .tag-unselected {
   /*
   p {
@@ -1594,5 +1610,6 @@ Filters / Tags Style Rules
     width: 48%;
   }
 }
+
 
 }

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -44,7 +44,7 @@ General style rules
   /* primary color for buttons, etc. */
   --panel-hover: rgba(254, 173, 129, 0.9);
   /* hover color for profile cards */
-  --header-color: #1a1921;
+  --header-color: #21202b;
   /* search bar, header button background, profile page background, etc. */
   --tab-color: rgba(26, 25, 33, 0.500);
   --second-tab-color: rgba(26, 25, 33, 0.650);
@@ -319,6 +319,8 @@ section {
   border: 2px solid black;
   box-shadow: 10px 10px 5px lightblue; */
 }
+
+
 
 /* Content areas to take up entire height of viewport
    to push the Footer to the bottom */
@@ -2621,6 +2623,18 @@ Theme Icons style rules
   fill: none;
   stroke: var(--invert-text);
 }
+/* Default tag text color follows theme */
+.tag-button,
+.tag-label {
+  color: var(--main-text) !important;
+}
+
+/* Light-background tags override text color */
+.tag-yellow,
+.tag-periwinkle,
+.tag-cyan {
+  color: black !important;
+}
 
 .project-image-hover>.filled-star>use,
 .star:hover>use {
@@ -2638,6 +2652,7 @@ Theme Icons style rules
   stroke: var(--main-text);
 }
 
+
 /* Fallback using CSS media queries */
 @media (prefers-color-scheme: light) {
   .svg-color-icon {
@@ -2650,5 +2665,6 @@ Theme Icons style rules
     /* filter: none; */
   }
 }
+
 
 /* #endregion */


### PR DESCRIPTION
Header-color changed according to Kaylah's request so that it matches the background color of the main/discover page. #21202b 

Tags font color change when switching between dark and light mode, for the font on lighter-background, it overrides the dark mode main color and stay dark font rather than light font color so that visibility of word is not affected(for tags only)