### PR TITLE
Light/Dark Mode + ProjectHoverQuote

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -866,7 +866,23 @@ Filters / Tags Style Rules
   p {
     margin: 0px;
     border: 0px;
-    color: var(--tag-text-selected);
+    color: var(--main-text);
+  }
+    /* Light-colored background tags will have dark text color */
+  .tag-yellow p,
+  .tag-periwinkle p,
+  .tag-cyan p {
+    color: black !important;
+  }
+
+  /* Dark-colored background tags stay theme text color */
+  .tag-blue p,
+  .tag-green p,
+  .tag-red p,
+  .tag-purple p,
+  .tag-pink p,
+  .tag-grey p {
+    color: var(--main-text) !important;
   }
 
   i {

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -287,9 +287,10 @@ Project Panel component style rules
   background-color: var(--header-color);
   color: var(--main-text);
   position: absolute;
+  top: 0px;
   left: 0px;
   right: 0px;
-  bottom: 0;
+  bottom: 0px;
   height: auto;
   max-height: 100%;
   visibility: visible;


### PR DESCRIPTION
(Accidently deleted branch before it could be merged - redo) 
Header-color changed according to Kaylah's request so that it matches the background color of the main/discover page. #21202b

Tags font color change when switching between dark and light mode, for the font on lighter-background, it overrides the dark mode main color and stay dark font rather than light font color so that visibility of word is not affected(for tags only)

Project Hover Quotes top margin fixed so that the words are not cut in half vertically