### PR TITLE
Project panel doesn't hide the image on hover anymore

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -296,7 +296,7 @@ Project Panel component style rules
   background-color: var(--header-color);
   color: var(--main-text);
   position: absolute;
-  top: 0px;
+  top: auto;
   left: 0px;
   right: 0px;
   bottom: 0px;


### PR DESCRIPTION
Examples:
<img width="380" height="576" alt="image" src="https://github.com/user-attachments/assets/2e92fb3f-978f-4e0e-8df5-998022c1fe3b" />
<img width="391" height="486" alt="image" src="https://github.com/user-attachments/assets/4537f697-4b41-4dc4-aea1-ec95c304a00b" />
