### PR TITLE
project/people filters z-index issue seems to be fixed?

### DIFF
--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -706,7 +706,17 @@ Filters / Tags Style Rules
   padding-left: 10px;
 
   .popup {
-    width: auto;
+    width: calc(100vw - 220px);
+    max-width: 70vw;
+  }
+}
+
+@media only screen and (max-width:800px) {
+  #discover-more-filters-container {
+
+    .popup {
+      width: 95vw;
+    }
   }
 }
 
@@ -754,6 +764,7 @@ Filters / Tags Style Rules
   color: var(--invert-text);
   font-weight: bold;
 }
+
 .discover-tag-filter-excluded:hover {
   background-color: var(--error-delete-color);
   color: var(--invert-text);
@@ -1312,6 +1323,12 @@ Filters / Tags Style Rules
   gap: 12px;
 }
 
+@media only screen and (max-width: 800px) {
+  .popup:has#filters-popup {
+    width: 95vw;
+  }
+}
+
 /* Header Text Style */
 #filters-popup h2 {
   text-align: center;
@@ -1592,9 +1609,9 @@ Filters / Tags Style Rules
   }
 
   .filter-tab {
-  width: fit-content !important;
-  padding: 6px 12px !important;
-}
+    width: fit-content !important;
+    padding: 6px 12px !important;
+  }
 
   #filter-tags {
     /* height: 80% !important; */


### PR DESCRIPTION
appears on top of sidebar (in desktop) and doesn't affect view of create project popup
<img width="922" height="691" alt="Screenshot 2026-07-20 at 11 51 43 AM" src="https://github.com/user-attachments/assets/e762af1f-2c2a-447b-b482-dda2bd0f158f" />
<img width="925" height="684" alt="Screenshot 2026-07-20 at 11 51 35 AM" src="https://github.com/user-attachments/assets/4ea9fb5e-fb6d-4d0a-b552-9ce5b8610112" />

<img width="929" height="682" alt="Screenshot 2026-07-20 at 11 51 52 AM" src="https://github.com/user-attachments/assets/2d8ac3e8-8fc5-431b-b35e-889d578808dd" />
