### PR TITLE
Quick fix mods can now see reported user option box

### DIFF
--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -854,7 +854,7 @@ const Profile = (userProfile: any) => {
           </div>
 
           {/* Mod options when this is a reported user */}
-          {(!isUsersProfile) && isUserMod && reportedUser ? <div id="mod-user-options">
+          {(!isUsersProfile) && isUserAdmin && reportedUser ? <div id="mod-user-options">
             <h4>Request Edits or Ban?</h4>
             {!reportedUser.active ? <p>This report is inactive at the moment because a moderator has warned the user and/or requested changes already.</p> : ""}
             <p>You can dismiss this report, request edits, or ban them.</p>

--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -854,7 +854,7 @@ const Profile = (userProfile: any) => {
           </div>
 
           {/* Mod options when this is a reported user */}
-          {(!isUsersProfile) && isUserAdmin && reportedUser ? <div id="mod-user-options">
+          {(!isUsersProfile) && isUserMod && reportedUser ? <div id="mod-user-options">
             <h4>Request Edits or Ban?</h4>
             {!reportedUser.active ? <p>This report is inactive at the moment because a moderator has warned the user and/or requested changes already.</p> : ""}
             <p>You can dismiss this report, request edits, or ban them.</p>


### PR DESCRIPTION
This box was hidden for mods because it accidently became an admin-only option. Now viewable for mods

<img width="1678" height="812" alt="image" src="https://github.com/user-attachments/assets/d1664484-6296-4908-bc27-4f4ca391d1c2" />
