### PR TITLE
Moderator report improvements

### DIFF
--- a/client/src/api/mod-tools.ts
+++ b/client/src/api/mod-tools.ts
@@ -177,21 +177,14 @@ export const sendModeratorNotification = async (data: ModeratorNotificationInput
  * @returns ApiResponse from the API call to ban a user and deleteUserReport
  */
 export const banUser = async (
-    reportId: number,
     data: BanUserInput
-): Promise<{ ban: ApiResponse, deleteReport: ApiResponse }> => {
+): Promise<ApiResponse> => {
     const apiUrl = `/mod/ban-user/${data.userId}`;
     const res = await POST(apiUrl, data);
 
-    const deleteReport = await deleteUserReport(reportId);
-
     if (res.error) console.log(`Error in banUser: ${res.error}`);
-    if (deleteReport.error) console.log(`Error in banUser(deleteReport): ${res.error}`);
 
-    return {
-        ban: res,
-        deleteReport: deleteReport,
-    };
+    return res;
 };
 
 /**

--- a/client/src/components/ModeratorTools/ReportedProjects.tsx
+++ b/client/src/components/ModeratorTools/ReportedProjects.tsx
@@ -29,8 +29,10 @@ const ReportedProjects = ({currentUserId, currentTab}: ReportedProjectsProps) =>
           if (reportedProjects !== undefined && reportedProjects!= null) {
             for (const project of reportedProjects) {
               const reportedId = await getByID(project.projectId);
-              tempPendingProjectArray.push(reportedId.data as ProjectWithFollowers);
-              tempIds.add(project.projectId);
+              if(reportedId.data?.projectId !== undefined && !tempIds.has(reportedId.data?.projectId)) {
+                tempPendingProjectArray.push(reportedId.data as ProjectWithFollowers);
+                tempIds.add(project.projectId);
+              }
             }
             setReportedProjectsIds(tempIds);
           }

--- a/client/src/components/pages/Profile.tsx
+++ b/client/src/components/pages/Profile.tsx
@@ -29,7 +29,7 @@ import { MeDetail, MePrivate, ProjectDetail, ProjectPreview, UserPreview, Role, 
 import { RitStatus as RitStatusLabel } from '@looking-for-group/shared/enums';
 import usePreloadedImage from "../../functions/imageLoad";
 import { reportUser } from "../../api/users";
-import { getReportedUsers, getUserAccessLevel, promoteToMod, demoteToUser, deleteUserReport, warnUser, banUser } from "../../api/mod-tools";
+import { getReportedUsers, getUserAccessLevel, promoteToMod, demoteToUser, deleteUserReport, warnUser, banUser, sendModeratorNotification, deactivateUserReport } from "../../api/mod-tools";
 import { PopupContext } from "../Popup";
 import { UserReport } from "@looking-for-group/shared";
 
@@ -68,7 +68,8 @@ const Profile = (userProfile: any) => {
   const [previousDisplayedProfileAccessLevel, setPreviousDisplayedProfileAccessLevel] = useState<UserAccessLevel>('User');
 
   const [isFollow, setIsFollow] = useState<boolean>(false); //for the buttons specifically
-  const [reportedUser, setReportedUser] = useState<UserReport>();
+  const [activeReportList, setActiveReportList] = useState<UserReport[]>([]);
+  const [inactiveReportList, setInactiveReportList] = useState<UserReport[]>([]);
 
   // stores all followed users to display on personal user profile
   const [followedProfilesList, setFollowedProfilesList] = useState<UserPreview[]>([]);
@@ -239,15 +240,19 @@ const Profile = (userProfile: any) => {
    * Checks if the user has been reported and updates the useState
    */
   const isUserReported = async () => {
+    const tempActiveList: UserReport[] = [];
+    const tempInactiveList: UserReport[] = [];
     const currentUser = parseInt(profileID);
     const reportedUsers = (await getReportedUsers()).data;
     if (reportedUsers !== null && reportedUsers !== undefined) {
       for (const report of reportedUsers) {
         if (report.reportedId === currentUser) {
-          setReportedUser(report);
+          report.active ? tempActiveList.push(report) : tempInactiveList.push(report);
         }
       }
     }
+    setActiveReportList(tempActiveList);
+    setInactiveReportList(tempInactiveList);
   };
 
   /**
@@ -557,38 +562,48 @@ const Profile = (userProfile: any) => {
      * @param action The action to take on the report ('dismiss', 'warn' or 'ban')
      */
   const resolveReport = async (action: 'dismiss' | 'warn' | 'ban') => {
-    if (!reportedUser) return;
+    if (activeReportList.length === 0) return;
 
     if (action === 'dismiss') {
-      const res = await deleteUserReport(reportedUser.reportId);
+      const res = await Promise.all(
+        activeReportList.map(r => deleteUserReport(r.reportId)) 
+      );
 
-      if (res?.status === 200) {
+      if (res?.every(r => r.status === 200)) {
         // refresh page
         window.location.reload();
       }
     } else if (action === 'warn') {
-      const res = await warnUser(reportedUser.reportId, {
-        message: modMessage?.current?.value ?? '',
-        receiverId: reportedUser.reportedId,
+      debugger;
+      const warnRes = await sendModeratorNotification({
+        message: modMessage.current?.value ?? '',
+        receiverId: parseInt(profileID) ?? 0,
         subjectLine: 'Action Required: Changes Requested to Your Profile',
         modUserId: userID ?? 0,
         type: 'Warning',
       });
 
-      if (res.deactivate.status === 200 && res.notification.status === 201) {
+      const deactivateRes = await Promise.all(activeReportList.map(
+        r => deactivateUserReport(r.reportId)
+      ));
+
+      if (warnRes.status === 201 && deactivateRes?.every(r => r.status === 200)) {
         // refresh page
         window.location.reload();
       }
     } else if (action === 'ban') {
-      const res = await banUser(
-        reportedUser.reportId,
+      const banRes = await banUser(
         {
           reason: modMessage?.current?.value ?? '',
-          userId: reportedUser.reportedId,
+          userId: parseInt(profileID) ?? 0,
         }
       );
 
-      if (res.ban.status === 200 && res.deleteReport.status === 200) {
+      const deactivateRes = await Promise.all(activeReportList.map(
+        r => deactivateUserReport(r.reportId)
+      ));
+
+      if (banRes.status === 200 && deactivateRes?.every(r => r.status === 200)) {
         // refresh page
         window.location.reload();
       }
@@ -859,11 +874,11 @@ const Profile = (userProfile: any) => {
           </div>
 
           {/* Mod options when this is a reported user */}
-          {(!isUsersProfile) && isUserMod && reportedUser ? <div id="mod-user-options">
+          {(!isUsersProfile) && isUserMod && (activeReportList.length !== 0) ? <div id="mod-user-options">
             <h4>Request Edits or Ban?</h4>
-            {!reportedUser.active ? <p>This report is inactive at the moment because a moderator has warned the user and/or requested changes already.</p> : ""}
             <p>You can dismiss this report, request edits, or ban them.</p>
-            <p>Reason for this report: {reportedUser.reason}</p>
+            <p style={{whiteSpace: "pre-wrap"}}>Reasons for this report:<br /> - {activeReportList.map(r => r.reason).join('\n - ')}</p>
+            <p style={{whiteSpace: "pre-wrap"}}>Previous Reports:<br /> - {inactiveReportList.map(r => r.reason).join('\n - ')}</p>
             <div id="mod-options-btns">
               <button id="mod-dismiss-btn" onClick={() => resolveReport('dismiss')} >Dismiss Report</button>
               <Popup>

--- a/client/src/components/pages/Project.tsx
+++ b/client/src/components/pages/Project.tsx
@@ -279,7 +279,7 @@ const Project = () => {
         window.location.reload();
       }
     } else if (action === 'unapprove project') {
-      //unnaprove all the projects, then delete the reports
+      //unnaprove the project, then delete the reports
       const unapproveRes = await unapproveProject(
         projectID,
         {
@@ -982,7 +982,7 @@ const Project = () => {
               <div className="mod-project-options">
                 <h4>Unapprove?</h4>
                 <p>You can ignore this report or request edits on this project.</p>
-                <p style={{whiteSpace: "pre-wrap"}}>Reason for this report:<br /> - {reportList.map(r => r.reason).join('\n - ')}</p>
+                <p style={{whiteSpace: "pre-wrap"}}>Reasons for this report:<br /> - {reportList.map(r => r.reason).join('\n - ')}</p>
                 <div id="mod-options-btns">
                   <button id="mod-dismiss-btn" onClick={() => resolveReport('dismiss')}>Dismiss Report</button>
                   <Popup>

--- a/client/src/components/pages/Project.tsx
+++ b/client/src/components/pages/Project.tsx
@@ -24,7 +24,7 @@ import { ProjectContext, ProjectStatus as ProjectStatusEnums, ProjectApprovalSta
 //import { router } from "../../../../server/src/api/routes/me.ts"
 import { reportProject } from "../../api/projects";
 import { getCurrentAccount } from "../../api/users";
-import { approveProjectRequest, deleteProjectRequest, getReportedProjects, getUserAccessLevel, deleteProjectReport, takeDownProject } from "../../api/mod-tools";
+import { approveProjectRequest, deleteProjectRequest, getReportedProjects, getUserAccessLevel, deleteProjectReport, unapproveProject } from "../../api/mod-tools";
 
 //Main component for the project page
 /**
@@ -50,7 +50,7 @@ const Project = () => {
   const [displayedProject, setDisplayedProject] =
     useState<ProjectWithFollowers>();
 
-  const [reportedProject, setReportedProject] = useState<ProjectReport>();
+  const [reportList, setReportList] = useState<ProjectReport[]>([]);
 
   type ApprovalStatusKey = keyof typeof ApprovalStatus;
   const [approvalStatus, setApprovalStatus] = useState<ApprovalStatusKey>('not-approved');
@@ -122,15 +122,17 @@ const Project = () => {
        * Checks if the project has been reported and updates the useState
        */
       const isProjectReported = async () => {
+        const tempReportList : ProjectReport[] = [];
         const currentProject = projectResp.data as ProjectPreview;
         const reportedProjects = await getReportedProjects();
         if (reportedProjects.data !== null && reportedProjects.data !== undefined) {
           for (const report of reportedProjects.data) {
             if (report.projectId === currentProject.projectId) {
-              setReportedProject(report);
+              tempReportList.push(report);
             }
           }
         }
+        setReportList(tempReportList);
       };
 
       isProjectReported();
@@ -267,25 +269,27 @@ const Project = () => {
    * @param action The action to take on the report ('dismiss' or 'unapprove project')
    */
   const resolveReport = async (action: 'dismiss' | 'unapprove project') => {
-    if (!reportedProject) return;
+    if (!reportList) return;
 
+    //delete all the reports
     if (action === 'dismiss') {
-      const res = await deleteProjectReport(reportedProject.reportId);
+      const res = await Promise.all(reportList.map(r => deleteProjectReport(r.reportId)));
 
-      if (res?.status === 200) {
-        // refresh page
+      if (res?.every(r => r.status === 200)) {
         window.location.reload();
       }
     } else if (action === 'unapprove project') {
-      const res = await takeDownProject(
-        reportedProject.reportId,
-        reportedProject.projectId,
+      //unnaprove all the projects, then delete the reports
+      const unapproveRes = await unapproveProject(
+        projectID,
         {
           reason: modMessage.current?.value ?? ''
         } as UnapproveProjectInput
       );
 
-      if (res.unapprove.status === 200 && res.deleteReport.status === 200) {
+      const deleteRes = await Promise.all(reportList.map(r => deleteProjectReport(r.reportId)));
+
+      if (unapproveRes.status === 200 && deleteRes?.every(r => r.status === 200)) {
         // refresh page
         window.location.reload();
       }
@@ -974,11 +978,11 @@ const Project = () => {
               : ""}
 
             {/* Mod options to accept, decline, or request changes to a reported project // are we doing edits on reported projects?  */}
-            {isUserAdmin && reportedProject ? (
+            {isUserAdmin && reportList.length !== 0 ? (
               <div className="mod-project-options">
                 <h4>Unapprove?</h4>
                 <p>You can ignore this report or request edits on this project.</p>
-                <p>Reason for this report: {reportedProject.reason}</p>
+                <p style={{whiteSpace: "pre-wrap"}}>Reason for this report:<br /> - {reportList.map(r => r.reason).join('\n - ')}</p>
                 <div id="mod-options-btns">
                   <button id="mod-dismiss-btn" onClick={() => resolveReport('dismiss')}>Dismiss Report</button>
                   <Popup>


### PR DESCRIPTION
Improved the workflow for handling reports, allowing moderators to see and deal with all reports for a user/project at once. This should probably be tested more, since it's awkward to test, especially the reporter feedback stuff.
Closes #2146 