### PR TITLE
Brady filter tab focus

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1356,10 +1356,10 @@ body.modal-open {
   text-align: center;
 }
 
-  .filter-tab:hover {
-  color: var(--primary-color);
-  font-weight: 700;
-  transform: none;
+  .filter-tab:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 3px;
+  border-radius: 4px;
 }
 
   .filter-tab.selected {


### PR DESCRIPTION
Should make the focus outline much better for the filter tabs, making them more reflect the shape of it and not just be a box around the element