### PR TITLE
No longer squishes match all button in filter popup on mobile views

### DIFF
--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1246,6 +1246,7 @@ body.modal-open {
 
   #match-button {
     width: fit-content;
+    min-width: 125px;
     height: 40px;
     padding: 5px 16px;
     font-size: 1.25rem;

--- a/client/src/components/Styles/general.css
+++ b/client/src/components/Styles/general.css
@@ -1246,7 +1246,7 @@ body.modal-open {
 
   #match-button {
     width: fit-content;
-    min-width: 125px;
+    min-width: 136px;
     height: 40px;
     padding: 5px 16px;
     font-size: 1.25rem;


### PR DESCRIPTION
<img width="294" height="77" alt="image" src="https://github.com/user-attachments/assets/7e03c471-9b26-4c95-885f-311cd5fb4e31" />
