### PR TITLE
Moderators cannot moderate self

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@types/html-to-text": "^9.0.4",
         "@types/nodemailer": "^8.0.0",
         "@types/prismjs": "^1.26.6",
-        "concurrently": "^10.0.3",
+        "concurrently": "^9.2.4",
         "cross-env": "^7.0.3",
         "dotenv-cli": "^8.0.0",
         "husky": "^9.1.7",
@@ -4803,16 +4803,46 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -4897,36 +4927,107 @@
       }
     },
     "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       }
     },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -4995,25 +5096,25 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "5.6.2",
+        "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
-        "supports-color": "10.2.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
-        "yargs": "18.0.0"
+        "yargs": "17.7.2"
       },
       "bin": {
-        "conc": "dist/bin/index.js",
-        "concurrently": "dist/bin/index.js"
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -5525,9 +5626,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6996,21 +7097,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7025,22 +7111,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -7071,18 +7141,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -7368,9 +7426,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -10719,6 +10777,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11207,9 +11275,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11683,13 +11751,16 @@
       "license": "MIT"
     },
     "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
@@ -12949,49 +13020,87 @@
       }
     },
     "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^9.0.1",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/html-to-text": "^9.0.4",
     "@types/nodemailer": "^8.0.0",
     "@types/prismjs": "^1.26.6",
-    "concurrently": "^10.0.3",
+    "concurrently": "^9.2.4",
     "cross-env": "^7.0.3",
     "dotenv-cli": "^8.0.0",
     "husky": "^9.1.7",

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -4462,6 +4462,13 @@ paths:
         - Mod
       security:
         - shibbolethAuth: []
+      parameters:
+        - in: query
+          name: devId
+          schema:
+            type: integer
+          required: false
+          description: The user ID to be used as the current user
       responses:
         '200':
           description: Project reports acquired successfully

--- a/server/src/api/middleware/authorization/requires-not-self.ts
+++ b/server/src/api/middleware/authorization/requires-not-self.ts
@@ -19,7 +19,7 @@ export const requiresNotSelf = (subjectParamLocation: ParameterLocation, subject
     if (meId === subjectResult) {
       const res: ApiResponse = {
         status: 403,
-        error: 'You cannot moderate yourself.',
+        error: 'You cannot do this yourself.',
       };
       response.status(res.status).json(res);
       return;

--- a/server/src/api/middleware/authorization/requires-not-self.ts
+++ b/server/src/api/middleware/authorization/requires-not-self.ts
@@ -2,6 +2,10 @@ import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/share
 import type { NextFunction, Response } from 'express';
 import type { ParameterLocation } from '#middleware/validators/parameter-location/parameter-location.ts';
 
+/**
+ * Checks if the subject of the action being performed is the same person as the one performing the action.
+ *  (e.g. moderator approving their own project)
+ */
 export const requiresNotSelf = (subjectParamLocation: ParameterLocation, subjectKey: string) => {
   return async (request: AuthenticatedRequest, response: Response, next: NextFunction) => {
     const subjectResult = await subjectParamLocation.getId(subjectKey, request);

--- a/server/src/api/middleware/authorization/requires-not-self.ts
+++ b/server/src/api/middleware/authorization/requires-not-self.ts
@@ -1,0 +1,26 @@
+import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { NextFunction, Response } from 'express';
+import type { ParameterLocation } from '#middleware/validators/parameter-location/parameter-location.ts';
+
+export const requiresNotSelf = (subjectParamLocation: ParameterLocation, subjectKey: string) => {
+  return async (request: AuthenticatedRequest, response: Response, next: NextFunction) => {
+    const subjectResult = await subjectParamLocation.getId(subjectKey, request);
+    if (typeof subjectResult !== 'number') {
+      response.status(subjectResult.status).json(subjectResult);
+      return;
+    }
+
+    const meId = request.currentUser.userId;
+
+    if (meId === subjectResult) {
+      const res: ApiResponse = {
+        status: 403,
+        error: 'You cannot moderate yourself.',
+      };
+      response.status(res.status).json(res);
+      return;
+    }
+
+    next();
+  };
+};

--- a/server/src/api/middleware/validators/parameter-location/me-param-location.ts
+++ b/server/src/api/middleware/validators/parameter-location/me-param-location.ts
@@ -1,14 +1,31 @@
-import type { ApiResponse, AuthenticatedRequest } from '@looking-for-group/shared';
+import type { ApiResponse } from '@looking-for-group/shared';
 import type { Request } from 'express';
+import prisma from '#config/prisma.ts';
 import type { ParameterLocation } from './parameter-location.ts';
 
 /**
  * Takes the user id from the authenticated request ('me').
  */
 export class MeParameterLocation implements ParameterLocation {
-  // eslint-disable-next-line @typescript-eslint/require-await
   async getId(_key: string, request: Request): Promise<number | ApiResponse> {
-    const authRequest: AuthenticatedRequest = request as AuthenticatedRequest;
-    return authRequest.currentUser.userId;
+    const meGid = request.session.gid;
+    if (!meGid) {
+      return { status: 200 };
+    }
+
+    try {
+      const meUid = await prisma.users.findFirst({
+        where: { googleId: meGid },
+        select: { userId: true },
+      });
+
+      return meUid?.userId as number;
+    } catch (e) {
+      console.error('There was an error in MeParameterLocation: ', e);
+      return {
+        status: 500,
+        error: 'Internal error.',
+      };
+    }
   }
 }

--- a/server/src/api/middleware/validators/parameter-location/project-reported-in-path-param-location.ts
+++ b/server/src/api/middleware/validators/parameter-location/project-reported-in-path-param-location.ts
@@ -1,0 +1,47 @@
+import type { ApiResponse } from '@looking-for-group/shared';
+import type { Request } from 'express';
+import getProjectReportByIdService from '#services/mod/get-project-report-by-id.ts';
+import getProjectByIdService from '#services/projects/get-proj-id.ts';
+import type { ParameterLocation } from './parameter-location.ts';
+
+/**
+ * Looks in a project report for the reported's id.
+ */
+export class ProjectReportedInPathParameterLocation implements ParameterLocation {
+  async getId(_key: string, request: Request): Promise<number | ApiResponse> {
+    const res: ApiResponse = { status: 0 };
+    const reportId = parseInt(request.params.id as string);
+
+    if (isNaN(reportId)) {
+      res.status = 400;
+      res.error = 'Invalid project id.';
+      return res;
+    }
+
+    const result = await getProjectReportByIdService(reportId);
+
+    if (result === 'INTERNAL_ERROR') {
+      res.status = 500;
+      res.error = 'There was an internal error.';
+      return res;
+    } else if (result === 'NOT_FOUND') {
+      res.status = 404;
+      res.error = 'Report not found.';
+      return res;
+    }
+
+    const projectResult = await getProjectByIdService(result.projectId);
+
+    if (projectResult === 'INTERNAL_ERROR') {
+      res.status = 500;
+      res.error = 'There was an internal error.';
+      return res;
+    } else if (projectResult === 'NOT_FOUND') {
+      res.status = 404;
+      res.error = 'Report not found.';
+      return res;
+    }
+
+    return projectResult.owner.userId;
+  }
+}

--- a/server/src/api/middleware/validators/parameter-location/project-reporter-in-path-param-location.ts
+++ b/server/src/api/middleware/validators/parameter-location/project-reporter-in-path-param-location.ts
@@ -1,0 +1,34 @@
+import type { ApiResponse } from '@looking-for-group/shared';
+import type { Request } from 'express';
+import getProjectReportByIdService from '#services/mod/get-project-report-by-id.ts';
+import type { ParameterLocation } from './parameter-location.ts';
+
+/**
+ * Looks in a project report for the reporter's id.
+ */
+export class ProjectReporterInPathParameterLocation implements ParameterLocation {
+  async getId(_key: string, request: Request): Promise<number | ApiResponse> {
+    const res: ApiResponse = { status: 0 };
+    const reportId = parseInt(request.params.id as string);
+
+    if (isNaN(reportId)) {
+      res.status = 400;
+      res.error = 'Invalid project id.';
+      return res;
+    }
+
+    const result = await getProjectReportByIdService(reportId);
+
+    if (result === 'INTERNAL_ERROR') {
+      res.status = 500;
+      res.error = 'There was an internal error.';
+      return res;
+    } else if (result === 'NOT_FOUND') {
+      res.status = 404;
+      res.error = 'Report not found.';
+      return res;
+    }
+
+    return result.userId;
+  }
+}

--- a/server/src/api/middleware/validators/parameter-location/reported-in-path-param-location.ts
+++ b/server/src/api/middleware/validators/parameter-location/reported-in-path-param-location.ts
@@ -1,0 +1,34 @@
+import type { ApiResponse } from '@looking-for-group/shared';
+import type { Request } from 'express';
+import getUserReportByIdService from '#services/mod/get-user-report-by-id.ts';
+import type { ParameterLocation } from './parameter-location.ts';
+
+/**
+ * Looks in a report for the reported's id.
+ */
+export class ReportedInPathParameterLocation implements ParameterLocation {
+  async getId(_key: string, request: Request): Promise<number | ApiResponse> {
+    const res: ApiResponse = { status: 0 };
+    const reportId = parseInt(request.params.id as string);
+
+    if (isNaN(reportId)) {
+      res.status = 400;
+      res.error = 'Invalid project id.';
+      return res;
+    }
+
+    const result = await getUserReportByIdService(reportId);
+
+    if (result === 'INTERNAL_ERROR') {
+      res.status = 500;
+      res.error = 'There was an internal error.';
+      return res;
+    } else if (result === 'NOT_FOUND') {
+      res.status = 404;
+      res.error = 'Report not found.';
+      return res;
+    }
+
+    return result.reportedId;
+  }
+}

--- a/server/src/api/middleware/validators/parameter-location/reporter-in-path-param-location.ts
+++ b/server/src/api/middleware/validators/parameter-location/reporter-in-path-param-location.ts
@@ -1,0 +1,34 @@
+import type { ApiResponse } from '@looking-for-group/shared';
+import type { Request } from 'express';
+import getUserReportByIdService from '#services/mod/get-user-report-by-id.ts';
+import type { ParameterLocation } from './parameter-location.ts';
+
+/**
+ * Looks in a report for the reporter's id.
+ */
+export class ReporterInPathParameterLocation implements ParameterLocation {
+  async getId(_key: string, request: Request): Promise<number | ApiResponse> {
+    const res: ApiResponse = { status: 0 };
+    const reportId = parseInt(request.params.id as string);
+
+    if (isNaN(reportId)) {
+      res.status = 400;
+      res.error = 'Invalid project id.';
+      return res;
+    }
+
+    const result = await getUserReportByIdService(reportId);
+
+    if (result === 'INTERNAL_ERROR') {
+      res.status = 500;
+      res.error = 'There was an internal error.';
+      return res;
+    } else if (result === 'NOT_FOUND') {
+      res.status = 404;
+      res.error = 'Report not found.';
+      return res;
+    }
+
+    return result.reporterId;
+  }
+}

--- a/server/src/api/routes/mod.ts
+++ b/server/src/api/routes/mod.ts
@@ -13,6 +13,7 @@ import { getUserReports } from '#controllers/mod/get-user-reports.ts';
 import { sendNotification } from '#controllers/mod/send-notification.ts';
 import { unbanUser } from '#controllers/mod/unban-user.ts';
 import { requiresNotSelf } from '#middleware/authorization/requires-not-self.ts';
+import { PathParameterLocation } from '#middleware/validators/parameter-location/path-param-location.ts';
 import { ProjectReportedInPathParameterLocation } from '#middleware/validators/parameter-location/project-reported-in-path-param-location.ts';
 import { ProjectReporterInPathParameterLocation } from '#middleware/validators/parameter-location/project-reporter-in-path-param-location.ts';
 import { ReportedInPathParameterLocation } from '#middleware/validators/parameter-location/reported-in-path-param-location.ts';
@@ -66,7 +67,12 @@ router.patch(
 );
 
 router.post('/notification', authenticated(sendNotification));
-router.post('/ban-user/:id', userExistsAt('path', 'id'), authenticated(banUser));
+router.post(
+  '/ban-user/:id',
+  userExistsAt('path', 'id'),
+  authenticated(requiresNotSelf(new PathParameterLocation(), 'id')),
+  authenticated(banUser),
+);
 
 router.delete('/delete-project/:id/', authenticated(deleteProject));
 router.delete('/unban-user/:googleId/', authenticated(unbanUser));

--- a/server/src/api/routes/mod.ts
+++ b/server/src/api/routes/mod.ts
@@ -12,6 +12,11 @@ import { getUserReportById } from '#controllers/mod/get-user-report-by-id.ts';
 import { getUserReports } from '#controllers/mod/get-user-reports.ts';
 import { sendNotification } from '#controllers/mod/send-notification.ts';
 import { unbanUser } from '#controllers/mod/unban-user.ts';
+import { requiresNotSelf } from '#middleware/authorization/requires-not-self.ts';
+import { ProjectReportedInPathParameterLocation } from '#middleware/validators/parameter-location/project-reported-in-path-param-location.ts';
+import { ProjectReporterInPathParameterLocation } from '#middleware/validators/parameter-location/project-reporter-in-path-param-location.ts';
+import { ReportedInPathParameterLocation } from '#middleware/validators/parameter-location/reported-in-path-param-location.ts';
+import { ReporterInPathParameterLocation } from '#middleware/validators/parameter-location/reporter-in-path-param-location.ts';
 import { userExistsAt } from '#middleware/validators/user-exists-at.ts';
 import { userReportExistsAt } from '#middleware/validators/user-report-exists-at.ts';
 import requiresLogin from '../middleware/authorization/requires-login.ts';
@@ -38,13 +43,25 @@ router.use(requiresLogin, injectCurrentUser, authenticated(requiresModerator));
 
 router.get('/project-report/', authenticated(getProjectReports));
 router.get('/user-report/', authenticated(getUserReports));
-router.get('/project-report/:id', authenticated(getProjectReportById));
-router.get('/user-report/:id', authenticated(getUserReportById));
+router.get(
+  '/project-report/:id',
+  authenticated(requiresNotSelf(new ProjectReporterInPathParameterLocation(), '')),
+  authenticated(requiresNotSelf(new ProjectReportedInPathParameterLocation(), '')),
+  authenticated(getProjectReportById),
+);
+router.get(
+  '/user-report/:id',
+  authenticated(requiresNotSelf(new ReporterInPathParameterLocation(), '')),
+  authenticated(requiresNotSelf(new ReportedInPathParameterLocation(), '')),
+  authenticated(getUserReportById),
+);
 
 router.patch('/clear-profile/:id/', authenticated(clearProfile));
 router.patch(
   '/user-report/:id/deactivate',
   userReportExistsAt('path', 'id'),
+  authenticated(requiresNotSelf(new ReporterInPathParameterLocation(), '')),
+  authenticated(requiresNotSelf(new ReportedInPathParameterLocation(), '')),
   authenticated(deactivateUserReport),
 );
 
@@ -53,7 +70,17 @@ router.post('/ban-user/:id', userExistsAt('path', 'id'), authenticated(banUser))
 
 router.delete('/delete-project/:id/', authenticated(deleteProject));
 router.delete('/unban-user/:googleId/', authenticated(unbanUser));
-router.delete('/project-report/:id', authenticated(deleteProjectReport));
-router.delete('/user-report/:id', authenticated(deleteUserReport));
+router.delete(
+  '/project-report/:id',
+  authenticated(requiresNotSelf(new ProjectReporterInPathParameterLocation(), '')),
+  authenticated(requiresNotSelf(new ProjectReportedInPathParameterLocation(), '')),
+  authenticated(deleteProjectReport),
+);
+router.delete(
+  '/user-report/:id',
+  authenticated(requiresNotSelf(new ReporterInPathParameterLocation(), '')),
+  authenticated(requiresNotSelf(new ReportedInPathParameterLocation(), '')),
+  authenticated(deleteUserReport),
+);
 
 export default router;

--- a/server/src/api/routes/projects.ts
+++ b/server/src/api/routes/projects.ts
@@ -2,8 +2,10 @@ import type { AuthenticatedRequest } from '@looking-for-group/shared';
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import { upload } from '#config/multer.ts';
 import PROJECT from '#controllers/projects/index.ts';
+import { requiresNotSelf } from '#middleware/authorization/requires-not-self.ts';
 import { isUserBlocked } from '#middleware/validators/is-user-blocked.ts';
 import { BodyParameterLocation } from '#middleware/validators/parameter-location/body-param-location.ts';
+import { ProjectInPathParameterLocation } from '#middleware/validators/parameter-location/project-in-path-param-location.ts';
 import requiresLogin from '../middleware/authorization/requires-login.ts';
 import requiresModerator from '../middleware/authorization/requires-mod.ts';
 import requiresProjectOwner from '../middleware/authorization/requires-project-owner.ts';
@@ -107,6 +109,7 @@ router.delete(
   injectCurrentUser,
   authenticated(requiresModerator),
   projectExistsAt('path', 'id'),
+  authenticated(requiresNotSelf(new ProjectInPathParameterLocation(), 'id')),
   authenticated(PROJECT.rejectProject),
 );
 //#endregion
@@ -123,6 +126,7 @@ router.patch(
   injectCurrentUser,
   authenticated(requiresModerator),
   projectExistsAt('path', 'id'),
+  authenticated(requiresNotSelf(new ProjectInPathParameterLocation(), 'id')),
   authenticated(PROJECT.approveProject),
 );
 
@@ -133,6 +137,7 @@ router.patch(
   injectCurrentUser,
   authenticated(requiresModerator),
   projectExistsAt('path', 'id'),
+  authenticated(requiresNotSelf(new ProjectInPathParameterLocation(), 'id')),
   authenticated(PROJECT.unapproveProject),
 );
 


### PR DESCRIPTION
Moderators/admins can no longer:
- Approve or reject their own projects' approval requests.
- Unapprove their own projects.
- View reports related to them or their projects.
- Remove reports related to them or their projects.
- Deactivate reports related to them or their projects.
- Ban themself.

Still needs frontend support. For instance, if a moderator presses "approve project" on their own project, it appears as though the project has been approved. However, upon reloading the page the project remains unapproved.