### PR TITLE
Updated Short Description label to account for Weez's criticism and updates to the project

### DIFF
--- a/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
@@ -259,7 +259,8 @@ export const GeneralTab = ({
 
       <LabelInputBox
         label={"Short Description"}
-        labelInfo="Share a brief summary of your project. This will be displayed in your project's discover card."
+        labelInfo="Give a brief overview of your project. This will be displayed on the Projects page,
+        and give important information to applicants."
         inputType={"multi"}
         id={"project-editor-description-input"}
         maxLength={300}


### PR DESCRIPTION
The Short Description's label on the Edit Project screen has been updated to this:

"Give a brief overview of your project. This will be displayed on the Projects page, and give important information to applicants."

I took aspects from both Weez's suggestion and what we already had on there. Also I referred to the Projects page since it's not called Discover anymore.