### PR TITLE
Update send invite/application notif builder and send invite service logic

### DIFF
--- a/server/src/notification-templates/invite-received-notification-builder.ts
+++ b/server/src/notification-templates/invite-received-notification-builder.ts
@@ -28,6 +28,8 @@ export class InviteReceivedNotificationBuilder implements NotificationBuilder {
       where: {
         prospectiveMemberId: receiverId,
         projectId,
+        roleId,
+        requestStatus: 'Pending',
       },
       select: {
         requestId: true,

--- a/server/src/notification-templates/request-to-join-notification-builder.ts
+++ b/server/src/notification-templates/request-to-join-notification-builder.ts
@@ -17,6 +17,7 @@ export class RequestToJoinNotificationBuilder implements NotificationBuilder {
 
     const req: AuthenticatedRequest = request as AuthenticatedRequest;
     const body: RequestToJoinInput = req.body as RequestToJoinInput;
+    const roleId: number = body.roleId;
     const projectId = parseInt(req.params.id as string);
     const prospectiveMemberId = body.prospectiveMemberId;
 
@@ -25,6 +26,8 @@ export class RequestToJoinNotificationBuilder implements NotificationBuilder {
       where: {
         projectId,
         prospectiveMemberId,
+        roleId,
+        requestStatus: 'Pending',
       },
       select: {
         requestId: true,

--- a/server/src/services/projects/members/send-invite.ts
+++ b/server/src/services/projects/members/send-invite.ts
@@ -140,21 +140,7 @@ const sendInviteService = async (
       HTMLBody: html,
     };
 
-    const emailResult = await sendEmail(email);
-    if (emailResult === 'INTERNAL_ERROR') {
-      // failed to send email -> rollback request
-      try {
-        await prisma.memberRequests.delete({
-          where: {
-            requestId: result.requestId,
-          },
-        });
-      } catch (rollbackError) {
-        console.error('Failed to rollback member request:', rollbackError);
-      }
-
-      return emailResult;
-    }
+    await sendEmail(email);
 
     return 'NO_CONTENT';
   } catch (e) {


### PR DESCRIPTION
- the query in the send invite/join request builders only looked for matching prospective member id and project id before, now also needs to match role id and status
- removed rollback in send invite now that we have the notification system set up