### PR TITLE
Prevent the project title from being squished by request review button at ~1300px

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -4029,6 +4029,7 @@ Project Carousel style rules
   margin-bottom: 5px;
   word-break: break-word;
   hyphens: auto;
+  min-width: 12vw;
 }
 
 #project-info-buttons {


### PR DESCRIPTION
Before: 
<img width="523" height="852" alt="image" src="https://github.com/user-attachments/assets/e06b0e83-727d-4cf5-adc6-9c79cad3f85e" />
After: 
<img width="581" height="396" alt="image" src="https://github.com/user-attachments/assets/03b3ac5f-681c-4cfb-a490-18199d390d16" />
