### PR TITLE
Prevent team tabs from going off screen on mobile

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -3805,8 +3805,14 @@ New Project Page style rules
   }
   #project-editor-team-tabs
   {
-    justify-content: flex-start;
+    /* justify-content: flex-start; */
     gap: 4%;
+    height: 80px;
+
+    button {
+      text-wrap: wrap !important;
+      max-width: 150px;
+    }
   }
   #project-editor-project-members
   {


### PR DESCRIPTION
<img width="417" height="433" alt="image" src="https://github.com/user-attachments/assets/7b366dc2-f0fa-4a63-a124-991250433174" />
