### PR TITLE
Make banned user's account private

### DIFF
--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -173,7 +173,8 @@ paths:
   # USERS
   /api/users/all/{method}:
     get:
-      summary: Get all users
+      summary: Get all public users
+      description: Returns only public users. Private users are banned and are excluded from the results.
       tags:
         - Users
       parameters:

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -4476,7 +4476,7 @@ paths:
 
   /api/mod/ban-user/{id}:
     post:
-      summary: Bans a user by adding them to a blacklist
+      summary: Bans a user by adding them to the blacklist, ending their current session, and hiding their account from public view
       tags:
         - Mod
       security:
@@ -4575,7 +4575,7 @@ paths:
 
   /api/mod/unban-user/{id}:
     delete:
-      summary: Unbans a user by removing them from a blacklist
+      summary: Unbans a user by removing them from the blacklist and making it publicly visible
       tags:
         - Mod
       security:

--- a/server/src/email-templates/ban-email.ts
+++ b/server/src/email-templates/ban-email.ts
@@ -75,7 +75,7 @@ const BanEmail = ({ receiverName, banReason }: BanEmailProps) => {
           createElement(
             Text,
             { className: 'text-[14px] text-black leading-[24px]' },
-            'Your account has been frozen, and you will be unable to join or create projects.',
+            'Your account has been frozen and hidden from public view. You can no longer create or join projects.',
             ' If you believe this was a mistake, contact us at ',
             createElement('strong', null, 'lookingforgrp@gmail.com'),
             '.',

--- a/server/src/email-templates/unban-email.ts
+++ b/server/src/email-templates/unban-email.ts
@@ -69,7 +69,7 @@ const UnbanEmail = ({ receiverName }: UnbanEmailProps) => {
             Text,
             { className: 'text-[14px] text-black leading-[24px]' },
             'You have been unbanned from LFG. ',
-            'Your account has been unfrozen, and you will be able to join or create projects again.',
+            'Your account has been unfrozen and is now visible to the public. You can once again create and join projects.',
           ),
           createElement(
             Text,

--- a/server/src/services/users/blacklist/add-to-blacklist.ts
+++ b/server/src/services/users/blacklist/add-to-blacklist.ts
@@ -38,6 +38,16 @@ const addBlacklistService = async (
 
     if (sessionResult === 'INTERNAL_ERROR') return sessionResult;
 
+    // make banned user's account private
+    await prisma.users.update({
+      where: {
+        userId,
+      },
+      data: {
+        privacy: 'private',
+      },
+    });
+
     //Send email to user
     const html = await pretty(
       await render(

--- a/server/src/services/users/blacklist/delete-from-blacklist.ts
+++ b/server/src/services/users/blacklist/delete-from-blacklist.ts
@@ -28,6 +28,16 @@ const deleteBlacklistService = async (
       },
     });
 
+    // make the user's account public again
+    await prisma.users.update({
+      where: {
+        userId: id,
+      },
+      data: {
+        privacy: 'public',
+      },
+    });
+
     //Send email to user
     const html = await pretty(
       await render(

--- a/server/src/services/users/get-all-users.ts
+++ b/server/src/services/users/get-all-users.ts
@@ -117,7 +117,10 @@ export const getAllUsersService = async (
     }
 
     const users = await prisma.users.findMany({
-      where: restrictionObject,
+      where: {
+        ...restrictionObject,
+        privacy: 'public',
+      },
       orderBy: orderByInput,
       select: UserDetailSelector,
     });

--- a/server/tests/userstest/blacklisttest/add-to-blacklist.test.ts
+++ b/server/tests/userstest/blacklisttest/add-to-blacklist.test.ts
@@ -13,6 +13,7 @@ vi.mock('#config/prisma.ts', () => ({
     },
     users: {
       findUnique: vi.fn(),
+      update: vi.fn(),
     },
     session: {
       deleteMany: vi.fn(),
@@ -47,12 +48,36 @@ const prismaUser: Users = {
   galleryEnabled: false,
 };
 
+const updatedUser: Users = {
+  userId: 1,
+  googleId: 'u123',
+  username: 'goldleaf',
+  firstName: 'Gold',
+  lastName: 'Leaf',
+  ritEmail: 'goldleaf@rit.edu',
+  profileImage: null,
+  headline: '',
+  pronouns: '',
+  title: '',
+  ritStatus: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  displayPhone: false,
+  location: '',
+  bio: '',
+  privacy: 'private',
+  phoneNumber: null,
+  accessLevel: 'User',
+  galleryEnabled: false,
+};
+
 describe('addBlacklistService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
   it('returns OK if successful', async () => {
     vi.mocked(prisma.users.findUnique).mockResolvedValue(prismaUser);
+    vi.mocked(prisma.users.update).mockResolvedValue(updatedUser);
     const result = await addBlacklistService(1, 'silly');
 
     expect(prisma.userBlacklist.create).toHaveBeenCalled();
@@ -66,6 +91,7 @@ describe('addBlacklistService', async () => {
   });
   it("deletes the banned user's sessions so they get logged out", async () => {
     vi.mocked(prisma.users.findUnique).mockResolvedValue(prismaUser);
+    vi.mocked(prisma.users.update).mockResolvedValue(updatedUser);
     const result = await addBlacklistService(1, 'silly');
 
     expect(prisma.session.deleteMany).toHaveBeenCalledWith({
@@ -77,6 +103,7 @@ describe('addBlacklistService', async () => {
   });
   it('returns INTERNAL_ERROR if the sessions cannot be deleted', async () => {
     vi.mocked(prisma.users.findUnique).mockResolvedValue(prismaUser);
+    vi.mocked(prisma.users.update).mockResolvedValue(updatedUser);
     vi.mocked(prisma.session.deleteMany).mockRejectedValue(new Error('womp womp'));
     const result = await addBlacklistService(1, 'silly');
 

--- a/server/tests/userstest/blacklisttest/delete-from-blacklist.test.ts
+++ b/server/tests/userstest/blacklisttest/delete-from-blacklist.test.ts
@@ -41,6 +41,29 @@ const prismaUser: Users = {
   displayPhone: false,
   location: '',
   bio: '',
+  privacy: 'private',
+  phoneNumber: null,
+  accessLevel: 'User',
+  galleryEnabled: false,
+};
+
+const updatedUser: Users = {
+  userId: 1,
+  googleId: 'u123',
+  username: 'goldleaf',
+  firstName: 'Gold',
+  lastName: 'Leaf',
+  ritEmail: 'goldleaf@rit.edu',
+  profileImage: null,
+  headline: '',
+  pronouns: '',
+  title: '',
+  ritStatus: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  displayPhone: false,
+  location: '',
+  bio: '',
   privacy: 'public',
   phoneNumber: null,
   accessLevel: 'User',
@@ -53,13 +76,14 @@ describe('deleteBlacklistService', async () => {
   });
   it('returns OK if successful', async () => {
     vi.mocked(prisma.users.findUnique).mockResolvedValue(prismaUser);
+    vi.mocked(prisma.users.update).mockResolvedValue(updatedUser);
     vi.mocked(sendEmail).mockResolvedValue('NO_CONTENT');
     const result = await deleteBlacklistService(1);
 
     expect(prisma.userBlacklist.delete).toHaveBeenCalled();
     expect(prisma.userBlacklist.delete).toHaveBeenCalledWith({
       where: {
-        googleId: '1',
+        googleId: 'u123',
       },
     });
     expect(result).toBe('OK');

--- a/server/tests/userstest/blacklisttest/delete-from-blacklist.test.ts
+++ b/server/tests/userstest/blacklisttest/delete-from-blacklist.test.ts
@@ -15,6 +15,7 @@ vi.mock('#config/prisma.ts', () => ({
     },
     users: {
       findUnique: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));

--- a/server/tests/userstest/get-all-users.test.ts
+++ b/server/tests/userstest/get-all-users.test.ts
@@ -107,6 +107,7 @@ describe('test getAllUsersService', () => {
               },
             },
           ],
+          privacy: 'public',
         },
       }),
     );
@@ -135,6 +136,7 @@ describe('test getAllUsersService', () => {
               },
             },
           ],
+          privacy: 'public',
         },
       }),
     );
@@ -180,6 +182,7 @@ describe('test getAllUsersService', () => {
               },
             },
           ],
+          privacy: 'public',
         },
       }),
     );
@@ -209,6 +212,7 @@ describe('test getAllUsersService', () => {
               },
             },
           ],
+          privacy: 'public',
         },
       }),
     );


### PR DESCRIPTION
- Made the banned user's account private
- Made the unbanned user's account public again
- Updated the get users service so it only returns public users
- Fixed broken unit tests for blacklist and get users
- Update the descriptions for the get all users, ban user, and unban user endpoints on Swagger