### PR TITLE
implimented multiple bug fixes and features

### DIFF
--- a/client/src/api/data-managers/project-data-manager.ts
+++ b/client/src/api/data-managers/project-data-manager.ts
@@ -117,7 +117,7 @@ export const projectDataManager = async (projectId: number) => {
         jobSkills: [],
         members: [],
         memberRequests: [],
-        ownerChanges: [],
+        ownerChange: {} as CRUDRequest<number>,
       },
       delete: {
         tags: [],
@@ -348,11 +348,8 @@ export const projectDataManager = async (projectId: number) => {
 
     // change owner requests
     try {
-      await runAndCollectErrors<number>(
-        "Changing owner",
-        updates.ownerChanges,
-        ({data}) => changeOwner(projectId, data)
-      );
+      if (updates.ownerChange.data)
+        await changeOwner(projectId, updates.ownerChange.data);
     } catch (error) {
       errorMessage += (error as { message: string}).message;
     }
@@ -1297,7 +1294,7 @@ export const projectDataManager = async (projectId: number) => {
   };
   
   const swapOwner = (request: CRUDRequest<number>) => {
-    changes.update.ownerChanges.push(request);
+    changes.update.ownerChange = request;
   };
 
   return {

--- a/client/src/components/DiscoverProfiles.tsx
+++ b/client/src/components/DiscoverProfiles.tsx
@@ -409,8 +409,9 @@ export const DiscoverProfiles: React.FC<DiscoverFiltersProps> = ({ updateItemLis
 
                               //Sets the index to the setActiveId value.
                               setActiveTabId(index);
-                              if (document.getElementById("filter-tags")) {
-                                document.getElementById("filter-tags").scrollTop = 0; //shows error but still works?
+                              let tags = document.getElementById("filter-tags")
+                              if (tags) {
+                                tags.scrollTop = 0; //shows error but still works?
                               }
                             }}
                           >

--- a/client/src/components/DiscoverProjects.tsx
+++ b/client/src/components/DiscoverProjects.tsx
@@ -379,7 +379,7 @@ export const DiscoverProjects: React.FC<DiscoverProjectsProps> = ({ updateItemLi
                                     tagLabel;
                         const type = 'Project Type';
                         const id = label === "New" ? -1 :
-                            allTags.find(tag => tag.label == label)?.tagId;
+                            allTags.find(tag => tag.label == label && tag.type === "Project Type")?.tagId; 
                         const tagObj: Tag = { tagId: id ?? 0, label, type, category: "Other" };
                         return (
                             <button key={`${type}-${label}`}

--- a/client/src/components/DiscoverProjects.tsx
+++ b/client/src/components/DiscoverProjects.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Popup, PopupButton, PopupContent } from './Popup';
 import { SearchBar } from './SearchBar';
 import { tags, projectTabs } from '../constants/tags';
@@ -539,8 +539,9 @@ export const DiscoverProjects: React.FC<DiscoverProjectsProps> = ({ updateItemLi
 
                                                         //Sets the index to the setActiveId value.
                                                         setActiveTabId(index);
-                                                        if (document.getElementById("filter-tags")) {
-                                                            document.getElementById("filter-tags").scrollTop = 0; //shows error but still works?
+                                                        let tags = document.getElementById("filter-tags")
+                                                        if (tags) {
+                                                            tags.scrollTop = 0; //shows error but still works?
                                                         }
                                                     }}
                                                 >

--- a/client/src/components/ImageUploader.tsx
+++ b/client/src/components/ImageUploader.tsx
@@ -413,6 +413,9 @@ const ImageUploader = ({
       <PopupContent confirmation={true} callback={closePopup}>
         <div className="project-crop">
         <label id="project-crop-header">Crop image for thumbnail usage</label>
+        <div className="project-crop-extra-info">
+          Crop your image to a set ratio that better matches the site.
+        </div>
         <canvas ref={canvas} id="canvas"
           onMouseDown={handleMouseDown}
           onMouseMove={handleMouseMove}
@@ -437,6 +440,9 @@ const ImageUploader = ({
 
           style={{aspectRatio:aspectRatio}}
         ></canvas>
+        <div className="project-crop-mouse-instructions">
+          <p>You can also drag the image around the view using the mouse,<br/>and zoom in and out with the scroll wheel.</p>
+        </div>
 
         {/* <img ref={tempImage} id="refImage" src={cropImg} alt={cropImg} /> */}
         <div id="aspect-row">
@@ -474,9 +480,6 @@ const ImageUploader = ({
             )}
           />
           </Select>
-        </div>
-        <div className="project-crop-mouse-instructions">
-          <p>You can also drag the image around the view using the mouse, and zoom in and out with the scroll wheel.</p>
         </div>
         <div id="hide-range-rows">  
           <div id="zoom-row">
@@ -564,9 +567,6 @@ const ImageUploader = ({
             >
             </input>
           </div>
-        </div>
-        <div className="project-crop-extra-info">
-          Crop your image to a set ratio that better matches the site.
         </div>
         <div className="confirm-project-crop">
           <PopupButton buttonId="project-crop-save" callback={sendImg} doNotClose={() => true}>Crop Image</PopupButton>

--- a/client/src/components/ImageUploader.tsx
+++ b/client/src/components/ImageUploader.tsx
@@ -56,8 +56,11 @@ const ImageUploader = ({
   const [zoom, setZoom] = useState(100);
   const [dX, setDX] = useState(0);
   const [dY, setDY] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
-  const [prevPos, setPrevPos] = useState<{x:number, y:number}>({x:0, y:0});
+
+  //changed to Ref instead of State so that
+  //the changes are read without needing a re-render
+  const isDragging = useRef(false);
+  const prevPos = useRef<{x:number, y:number}>({x:0, y:0});
 
   const [cropFile, setCropFile] = useState<File>();
   const [cropImg, setCropImg] = useState<string>();
@@ -84,19 +87,18 @@ const ImageUploader = ({
   const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (e.button === 0 || e.button === 1 || e.button === 2) {
       e.preventDefault(); // stop context menu
-      setIsDragging(true);
-      setPrevPos({ x: e.clientX, y: e.clientY });
-
+      isDragging.current = true;
+      prevPos.current = { x: e.clientX, y: e.clientY };
     }
   };
 
   const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isDragging || !tempImage.current || !canvas.current) return;
+    if (!isDragging.current || !tempImage.current || !canvas.current) return;
 
     const rect = canvas.current.getBoundingClientRect();
 
-    const deltaX = (e.clientX - prevPos.x) * (canvas.current.width / rect.width);
-    const deltaY = (e.clientY - prevPos.y) * (canvas.current.height / rect.height);
+    const deltaX = (e.clientX - prevPos.current.x) * (canvas.current.width / rect.width);
+    const deltaY = (e.clientY - prevPos.current.y) * (canvas.current.height / rect.height);
 
     const rawDX = dX - deltaX;
     const rawDY = dY -deltaY;
@@ -107,7 +109,7 @@ const ImageUploader = ({
     setDX(newDX);
     setDY(newDY);
 
-    setPrevPos({ x: e.clientX, y: e.clientY });
+    prevPos.current = { x: e.clientX, y: e.clientY };
     updateCanvas();
   };
 
@@ -147,7 +149,7 @@ const ImageUploader = ({
   };
 
   const handleMouseUp = () => {
-    setIsDragging(false);
+    isDragging.current = false;
   };
 
 //wheel zooming for cropping

--- a/client/src/components/Profile/tabs/AboutTab.tsx
+++ b/client/src/components/Profile/tabs/AboutTab.tsx
@@ -83,7 +83,7 @@ export const AboutTab = ({
 	const handleFileSelected = useCallback(async (file: File) => {
 		if (!["image/jpeg", "image/png"].includes(file.type)) return;
 		else if (file.size > 1000000) {
-			setImageError("File too large");
+			setImageError("File too large (max: 1mb)");
 			return;
 		}
 

--- a/client/src/components/Profile/tabs/GalleryTab.tsx
+++ b/client/src/components/Profile/tabs/GalleryTab.tsx
@@ -79,7 +79,7 @@ export const GalleryTab: React.FC<GalleryTabProps> = ({
    */
   const handleImageUpload = useCallback((image: File, altText?: string) => {
     if (image.size > 2000000) {
-      setUploadError("File too large!");
+      setUploadError("File too large! (max: 2mb)");
       return;
     }
     else {

--- a/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/MediaTab.tsx
@@ -138,7 +138,7 @@ export const MediaTab = ({
   const handleImageUpload = useCallback(async (file: File, altText?: string) => {
     if (!["image/jpeg", "image/png"].includes(file.type)) return;
     else if (file.size > 2000000) {
-      setImageError("File too large");
+      setImageError("File too large! (max: 2mb)");
       return;
     }
 

--- a/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
@@ -26,7 +26,6 @@ import {
 } from "../../../api/users";
 import {
 	getMemberRequestByProjectID,
-	changeOwner,
 } from "../../../api/projects"
 import {
 	ProjectJob,
@@ -225,7 +224,6 @@ export const TeamTab = ({
 	const [confirm, setConfirm] = useState(false);
 
 	const [newOwner, setNewOwner] = useState<UserPreview | null>(null);
-	const [ownerChange, setOwnerChange] = useState("");
 	/**
 	 * Handles invitation request in local and data manager
 	 */
@@ -2159,64 +2157,6 @@ export const TeamTab = ({
 											/>
 										</Select>
 									</div>
-									{projectAfterTeamChanges.owner.userId === currentMember?.user?.userId
-										&& currentMember.role?.label.toLowerCase() !== "owner" ?
-										<div id="project-team-change-owner">
-											<label>Choose a member to take ownership of the project</label>
-											<div id="user-search-container">
-												<Dropdown>
-													<DropdownButton buttonId="user-search-dropdown-button">
-														<SearchBar
-															key={searchBarKey}
-															value={ownerChange}
-															onChange={(e) =>
-																setOwnerChange(e.target.value)
-															}
-															dataSets={[
-																{ data: projectAfterTeamChanges.members }
-															]}
-															onSearch={(results) => {
-																handleSearch(
-																	results as UserPreview[][]
-																);
-															}}
-															placeholderText='Search Members'>
-														</SearchBar>
-													</DropdownButton>
-													<DropdownContent>
-														<div id="user-search-results">
-															{projectAfterTeamChanges.members.map(
-																(user, index) => (
-																	<DropdownButton
-																		key={user.user?.userId}
-																		className={`user-search-item
-																		${index === 0 ? "top" : ""}
-																		${index === searchResults.length - 1 ? "bottom" : ""}`}
-																		callback={() => {
-																			setNewOwner(user.user);
-																			setOwnerChange(`${user.user?.firstName} ${user.user?.lastName} (${user.user?.username})`)
-																			if (errorAddMember === "To relinquish ownership, you must select a new owner.")
-																				setErrorAddMember("");
-																		}
-																		}
-																	>
-																		<p className="user-search-name">
-																			{user.user?.firstName}{" "}
-																			{user.user?.lastName}
-																		</p>
-																		<p className="user-search-username">
-																			{user.user?.username}
-																		</p>
-																	</DropdownButton>
-																)
-															)}
-														</div>
-													</DropdownContent>
-												</Dropdown>
-											</div>
-										</div> :
-										""
-									}
 									{errorAddMember !== "" ?
 										<div>
 											{errorAddMember}
@@ -2230,8 +2170,7 @@ export const TeamTab = ({
 											doNotClose={() =>
 												!currentMember ||
 												!currentMember.user ||
-												!currentMember.user.userId ||
-												(currentMember.user.userId === projectAfterTeamChanges.owner?.userId && !newOwner)
+												!currentMember.user.userId
 											}
 											callback={() => {
 												if (!currentMember) {
@@ -2241,53 +2180,9 @@ export const TeamTab = ({
 												if (!currentMember.user || !currentMember.user.userId) {
 													setErrorAddMember("Member is missing user information.");
 													return;
-												} // cant edit owner role
-												if (currentMember.user.userId === projectAfterTeamChanges.owner?.userId && !newOwner) {
-													setErrorAddMember("To relinquish ownership, you must select a new owner.");
-													return;
 												}
 												//if (isNullOrUndefined(currentMember.user)) return;
 
-												if (newOwner) {
-													dataManager?.swapOwner({
-														id: {
-															type: "canon",
-															value: newOwner.userId,
-														},
-														data: newOwner.userId,
-													});
-													dataManager?.updateMember({
-														id: {
-															type: "canon",
-															value: newOwner.userId,
-														},
-														data: {
-															roleId: 77,
-															profileVisibility: "public"
-														}
-													})
-													let newMembers = structuredClone(projectAfterTeamChanges.members).map(
-														(member) => {
-															// if this member matches the updated member
-															if (
-																newOwner
-																	.userId ===
-																member.user
-																	?.userId
-															) {
-																// update role
-																return {
-																	...member,
-																	role: { label: "Owner", roleId: 77 }
-																} as PendingProjectMember;
-															} else {
-																// if it doesn't match, do nothing to the member
-																return member;
-															}
-														}
-													);
-													projectAfterTeamChanges.members = newMembers;
-												}
 												// update member in data manager
 												try {
 													dataManager?.updateMember({
@@ -2338,6 +2233,7 @@ export const TeamTab = ({
 												updatePendingProject(
 													projectAfterTeamChanges
 												);
+                        setErrorAddMember("");
 											}}>
 											Save
 										</PopupButton>
@@ -2685,6 +2581,93 @@ export const TeamTab = ({
 		]
 	);
 
+  const projectOwnershipContent: JSX.Element = useMemo(() => 
+    <div id="project-editor-change-owner">
+      <div
+        key={projectAfterTeamChanges.owner.userId}
+        className="project-editor-owner-info"
+      >
+        <label>Current Owner</label>
+        <div className="project-editor-project-owner-extra">
+          <div id="owner-name">
+            {projectAfterTeamChanges.owner.firstName} {projectAfterTeamChanges.owner.lastName}
+          </div>
+          <div id="owner-user">
+            {projectAfterTeamChanges.owner.username}
+          </div>
+        </div>
+        <img
+          className="project-owner-image"
+          src={projectAfterTeamChanges.owner.profileImage ?? profileImage}
+          alt="profile image"
+          title={"Profile picture"}
+          // Cannot use usePreloadedImage function because this is in a callback
+          onError={(e) => {
+            const profileImg = e.target as HTMLImageElement;
+            profileImg.src = profileImage;
+          }}
+        />
+      </div>
+      {unmodifiedProject.owner.userId === currentUserId ? 
+        <div id="project-editor-owner-options">
+          <label>change owner</label>
+            <Select>
+              <SelectButton
+                placeholder="Select"
+                initialVal=""
+                type="input"
+                searchable={true}
+              />
+              <SelectOptions
+                callback={(e) => {
+                  setNewOwner(allUsers.find(user => user.userId === Number.parseInt((e.target as HTMLButtonElement).value)) ?? null)
+                }}
+                options={
+                projectAfterTeamChanges.members
+                .filter(m => m.user?.userId !== projectAfterTeamChanges.owner.userId)
+                .map((member) => {
+                  return {
+                    markup: <>
+                      <p className="user-search-name">
+                        {member.user?.firstName}{" "}
+                        {member.user?.lastName}
+                      </p>
+                      <p className="user-search-username">
+                        {member.user?.username}
+                      </p></>,
+                    value: member.user?.userId + "",
+                    disabled: false
+                  };
+                })}
+              />
+            </Select>
+          {newOwner?.userId !== projectAfterTeamChanges.owner.userId ? 
+            <div id="project-editor-owner-confirm">
+              <label>confirm</label>
+              <button id="change-owner-confirm"
+              onClick={() => {
+                if (newOwner) {
+                  dataManager?.swapOwner({
+                    id: {
+                      type: "canon",
+                      value: newOwner.userId,
+                    },
+                    data: newOwner.userId,
+                  });
+                  projectAfterTeamChanges.owner = newOwner;
+                  updatePendingProject(projectAfterTeamChanges);
+                }
+              }}
+              >
+                Change Ownership
+              </button>
+            </div> 
+          : <></>}
+        </div>
+      : <></>}
+    </div>
+  , [projectAfterTeamChanges, currentUserId, searchBarKey, newOwner, searchResults]);
+
 	// Set content depending on what tab is selected
 	const teamTabContent =
 		currentTeamTab === 0 ? (
@@ -2693,7 +2676,9 @@ export const TeamTab = ({
 			currentRequestsContent
 		) : currentTeamTab === 2 ? (
 			openPositionsContent
-		) : (
+		) : currentTeamTab === 3 ? (
+      projectOwnershipContent
+    ) : (
 			<></>
 		);
 
@@ -2729,6 +2714,18 @@ export const TeamTab = ({
 					}}
 					className={`button-reset project-editor-team-tab ${currentTeamTab === 2 ? "team-tab-active" : ""}`}>
 					Open Positions{" "}
+					{isOpenPositionsUnsaved && (
+						<span className="unsaved-indicator">(Unsaved)</span>
+					)}
+				</button>
+				<button
+					onClick={() => {
+						setCurrentTeamTab(
+							3
+						); /*setTeamTabContent(openPositionsContent);*/
+					}}
+					className={`button-reset project-editor-team-tab ${currentTeamTab === 3 ? "team-tab-active" : ""}`}>
+					Project Ownership{" "}
 					{isOpenPositionsUnsaved && (
 						<span className="unsaved-indicator">(Unsaved)</span>
 					)}

--- a/client/src/components/SignupProcess/CompleteProfile.tsx
+++ b/client/src/components/SignupProcess/CompleteProfile.tsx
@@ -150,6 +150,10 @@ const CompleteProfile: React.FC<CompleteProfileProps> = ({
 
 	// Loads and utilizes an imported function for setting a profile picture
 	const handleUploadPfp = (file: File) => {
+		if (file.size > 1000000) {
+			setError("File too large (max: 1mb)");
+			return;
+		}
 		console.log("uploading pfp");
 		const reader = new FileReader();
 		reader.onload = (event) => {

--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -142,8 +142,8 @@ Meet page hero style rules
   grid-area: blurb2;
   position: relative;
 
-  width: 120%;
-  height: 21vw;
+  width: 100%;
+  height: 19vw;
 
   .panel-text {
     width: 95%;

--- a/client/src/components/Styles/discoverMeet.css
+++ b/client/src/components/Styles/discoverMeet.css
@@ -142,8 +142,8 @@ Meet page hero style rules
   grid-area: blurb2;
   position: relative;
 
-  width: 100%;
-  height: 20vw;
+  width: 120%;
+  height: 21vw;
 
   .panel-text {
     width: 95%;

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -2684,20 +2684,19 @@ button.edit-position-contact .project-member-image {
 }
 
 .project-crop {
-  width: 100%;
+  width: 700px;
   text-align: center;
-  height: 1100px;
-  margin: 20px 20px;
+  height: 100%;
+  padding: 20px;
 
   #project-crop-header {
     display: block;
-    padding-top: 1em;
   }
 
   #canvas {
     border: 3px solid var(--primary-color);
     border-radius: 10px;
-    margin: 1vw 0;
+    margin-top: 10px;
     object-fit: cover;
     max-width: 95%;
     max-height: 400px;
@@ -2747,15 +2746,13 @@ button.edit-position-contact .project-member-image {
   }
 
   .project-crop-extra-info {
-    margin-top: 20px;
     font-size: 0.75rem;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
   }
 
   .project-crop-mouse-instructions {
-    margin-top: 20px;
     font-size: 0.75rem;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
 
     p {
       margin-top: 0;
@@ -2764,7 +2761,7 @@ button.edit-position-contact .project-member-image {
   }
 
   #alt-text-input {
-    margin: 10px auto 0 auto;
+    margin: 10px auto ;
     width: 85%;
 
     input {
@@ -2786,7 +2783,6 @@ button.edit-position-contact .project-member-image {
     flex-direction: row;
     gap: 20px;
     padding-top: 10px;
-    padding-bottom: 20px;
     width: 100%;
     justify-content: center;
   }

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -1452,9 +1452,7 @@ Project Creator and Editor Popup style rules
 
 /* Project Editor/Creator Team Tab */
 .project-editor-team-tab {
-  padding: 1%;
-  padding-left: 3%;
-  padding-right: 3%;
+  padding: 1% 2%;
   max-width: 100%;
   color: var(--neutral-gray);
   font-size: 2ch;
@@ -1897,6 +1895,76 @@ Project Creator and Editor Popup style rules
   font-weight: 700;
   color: var(--header-color);
   font-size: 1.6ch;
+}
+
+#project-editor-change-owner {
+  background-color: var(--bg-color);
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.10);
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  text-align: center;
+  gap: 100px;
+  margin-bottom: 20px;
+  width: 100%;
+  max-width: 1141px;
+  height: fit-content;
+  
+  .project-editor-owner-info {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--header-color);
+    border-radius: 10px;
+
+    img {
+      height: 320px;
+      margin: 20px;
+      border-radius: 10px;
+      object-fit: contain;
+      border: 3px solid var(--primary-color);
+    }
+
+    .project-editor-project-owner-extra {
+      padding-top: 10px;
+
+      #owner-name {
+        color: var(--primary-color);
+        text-align: center;
+        font-size: 1.5rem;
+      }
+    }
+  }
+
+  #project-editor-owner-options {
+    margin: auto 0;
+    width: 40%;
+
+    .select-container {
+      margin: 0 auto;
+      width: 80%;
+    }
+
+    #project-editor-owner-confirm {
+      display: flex;
+      flex-direction: column;
+      margin-top: 40px;
+      gap: 20px;
+
+      #change-owner-confirm {
+        margin: 0 auto;
+        width: min-content;
+        padding: 10px 5px;
+        border: none;
+        border-radius: 20px;
+        background-color: var(--primary-color);
+        color: var(--invert-text);
+        font-weight: 800;
+      }
+    }
+  }
 }
 
 /* Merge popup: a comfortable content-sized box instead of the nested-popup

--- a/client/types/types.d.ts
+++ b/client/types/types.d.ts
@@ -205,7 +205,7 @@ interface ProjectChangesUpdates {
   /**
    * Ownership change, special data type doesn't seem nessecary
    */
-  ownerChanges: CRUDRequest<number>[];
+  ownerChange: CRUDRequest<number>;
 }
 
 /**


### PR DESCRIPTION
### #2255 
<img width="1189" height="347" alt="image" src="https://github.com/user-attachments/assets/519bde6d-4515-4098-8c86-c8ebaa38cc76" />
altered middle image placement to better align with the other 2

### #2431 
<img width="994" height="98" alt="image" src="https://github.com/user-attachments/assets/6216ba8a-3689-4032-a86d-dafb771d4f2d" />
caused by the .some() method return true for a different tag first, so added type matching as well, to ensure that only project types are found

### #2497 
<img width="763" height="853" alt="image" src="https://github.com/user-attachments/assets/ddb21ac4-8689-49c9-9a6f-ea81cb098c50" />
altered the layout to both make more sense, and fit within the normal size constraints without needing a scroll bar. 
Also added to the error messages to include the maximum size of each upload spot.

### #2498 and #2512 
<img width="627" height="102" alt="image" src="https://github.com/user-attachments/assets/bfeffd35-ff3d-455e-9424-0a0f0603595a" />

fix from my previous PR fixed the gallery issue, fixed dragging the image by changing the state checkers into ref variables, which allows the changes to be read without waiting for a re-render.

### #2518 
<img width="1041" height="559" alt="image" src="https://github.com/user-attachments/assets/4c83daa5-2f3c-41f5-a6d7-eebc0da2ee88" />
since user role has no effect on project ownership, the owner can now change their project role freely while maintaining ownership. ownership transferring is now held within a separate team tab. it's a little ugly but I trust someone else can make it look good.