### PR TITLE
fix mobile css for bug reports list

### DIFF
--- a/client/src/components/PanelBox.tsx
+++ b/client/src/components/PanelBox.tsx
@@ -96,7 +96,12 @@ export const PanelBox = ({ category, itemList, projectCache, followedProjectIds,
     if (isMobile) columns = 2; //changed from 1 to 2 
     else if (isTabletProfile) columns = 2;
   }
-  //This is for projects and bugs
+  else if (category == 'bugs')
+  {
+    columns = 2;
+    if (isMobile) columns = 1; //changed from 1 to 2
+  }
+  //This is for projects
   else {
     if (isMobile) columns = 2; //changed from 1 to 2 
     else if (isTablet) columns = 2;

--- a/client/src/components/Styles/modPage.css
+++ b/client/src/components/Styles/modPage.css
@@ -91,7 +91,7 @@
         border-style: solid;
         /* Need big padding in the bottom to fit the tooltip */
         padding: 10px 10px 30px;
-        max-height: 500px;
+        max-height: 60vh;
         overflow-y: auto;
         overflow-x: hidden;
     }
@@ -307,7 +307,9 @@
 
 /* Bug Panel */
 .bug-panel {
-    width: 100%;
+    width: calc(100% - 20px);
+    min-width: fit-content;
+    padding: 10px;
     height: auto;
     border: none;
     border-radius: 10px;
@@ -335,6 +337,8 @@
         display: flex;
         flex-direction: row;
         gap: 10px;
+        justify-content: center;
+        align-items: center;
     }
 
     .bug-reporter-profile {
@@ -681,6 +685,18 @@
             #mod-dismiss-btn {
                 font-size: 1em;
             }
+        }
+    }
+    .bug-panel {
+        width: calc(100% - 20px);       /* accounts for padding + a little extra room */
+        h2 {
+            font-size: 1rem;
+        }
+        #see-details-btn {
+            font-size: 1.5ch;
+        }
+        .bug-reporter-info {
+            width: fit-content;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/2529
Also adjusted max height of mod page tab containers

Mobile

<img width="452" height="780" alt="image" src="https://github.com/user-attachments/assets/7bd1d5e9-0231-495c-9a92-07b3620a7a31" />


Desktop

<img width="1132" height="845" alt="image" src="https://github.com/user-attachments/assets/ff1e7e60-f34e-4209-ba5a-0645272b00c2" />

Tablet

<img width="527" height="767" alt="image" src="https://github.com/user-attachments/assets/7938cbb3-4297-461d-a355-da4eb6911896" />
