### PR TITLE
Added scrolling to team tabs on mobile in project editor

### DIFF
--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -3997,7 +3997,7 @@ New Project Page style rules
   }
 
   #project-editor-team-tabs {
-    /* justify-content: flex-start; */
+    justify-content: flex-start;
     gap: 4%;
     height: 80px;
 
@@ -4005,6 +4005,10 @@ New Project Page style rules
       text-wrap: wrap !important;
       max-width: 150px;
     }
+  }
+
+  #project-editor-team-tabs::-webkit-scrollbar-thumb {
+      background-color: rgb(113, 114, 118);
   }
 
   #project-editor-project-members {


### PR DESCRIPTION
<img width="981" height="1788" alt="image" src="https://github.com/user-attachments/assets/8ecdad42-0a95-4c8f-9359-a960b2518f61" />
The scrollbar color might be a little ugly, but I just wanted to make sure it was visible. Closes #2567