### PR TITLE
Phraasing changed on excluded content warnings

### DIFF
--- a/client/src/components/DiscoverProjects.tsx
+++ b/client/src/components/DiscoverProjects.tsx
@@ -662,7 +662,7 @@ export const DiscoverProjects: React.FC<DiscoverProjectsProps> = ({ updateItemLi
                             <i className='fa fa-close'></i>
                             {/* Excluded tags read as "Not Horror" so they aren't
                                 mistaken for something the project must match */}
-                            <p>{excluded ? `Not ${tag.label}` : tag.label}</p>
+                            <p>{excluded ? `${tag.label} Excluded` : tag.label}</p>
                         </TagElement>
                     ))}
                     <button


### PR DESCRIPTION
<img width="793" height="57" alt="image" src="https://github.com/user-attachments/assets/2cef1f22-a764-482e-b7d0-86b566f0736d" />
closes #2577