### PR TITLE
Welcome page is centered + selected skills section signup changes [mobile]

### DIFF
--- a/client/src/components/SignupProcess/ChooseSkills.tsx
+++ b/client/src/components/SignupProcess/ChooseSkills.tsx
@@ -7,6 +7,8 @@ import { SortableContext, arrayMove, sortableKeyboardCoordinates, verticalListSo
 import { SortableTag } from "../ProjectCreatorEditor/tabs/SortableItem";
 import TagDisplay, { skillToTagOrSkill } from "../TagDisplay";
 import { ThemeIcon } from "../ThemeIcon";
+import { Dropdown, DropdownButton, DropdownContent } from "../Dropdown";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 const skillTabs = ["Developer", "Designer", "Soft", "Audio", "Engineer"];
 
@@ -63,6 +65,9 @@ const ChooseSkills: React.FC<ChooseSkillsProps> = ({
 	const [searchedSkills, setSearchedSkills] = useState<Skill[]>([]);
 
 	const [searchValue, setSearchValue] = useState("");
+
+	// Used for ChooseSkills
+	const isMobile = useMediaQuery('(max-width: 1000px)');
 
 	mode;
 	/**
@@ -206,60 +211,126 @@ const ChooseSkills: React.FC<ChooseSkillsProps> = ({
 					</h1>
 					<p id="signupProcess-subTitle">You can edit them later</p>
 					<div id="profile-editor-tags">
-						<div id="project-editor-selected-tags">
-							<div className="project-editor-section-header">
-								Selected Skills
-							</div>
-							<div className="project-editor-extra-info">
-								Drag and drop to reorder
-							</div>
-							<DndContext
-								sensors={sensors}
-								collisionDetection={closestCenter}
-								onDragEnd={handleDragEnd}
-							>
-								<SortableContext
-									items={selectedSkills.map((t) => t.skillId)}
-									strategy={verticalListSortingStrategy}
-								>
-									<div id="project-editor-selected-tags-container">
-										{selectedSkills.map((skill) => (
-											<Fragment key={skill.skillId}>
-												<SortableTag
-													id={skill.skillId}
-													tag={skill}
-													onRemove={handleSkillToggle}
+						{isMobile ?
+						<Dropdown>
+							<DropdownButton buttonId="choose-skills-select-dropdown">
+								<div className="project-editor-section-header">
+										Selected Skills
+								</div>
+								<ThemeIcon
+              						id={'dropdown-arrow'}
+              						width={15}
+              						height={12}
+              						className={`color-fill select-button-arrow`}
+              						ariaLabel={'dropdown arrow'}/>
+							</DropdownButton>
+							<DropdownContent>
+								<div id="project-editor-selected-tags">
+									<div className="project-editor-extra-info">
+										{selectedSkills.length <= 0 ? 'Skills that you select will appear here' : 'Drag and drop to reorder'}
+									</div>
+									<DndContext
+										sensors={sensors}
+										collisionDetection={closestCenter}
+										onDragEnd={handleDragEnd}
+									>
+										<SortableContext
+											items={selectedSkills.map((t) => t.skillId)}
+											strategy={verticalListSortingStrategy}
+										>
+											<div id="project-editor-selected-tags-container">
+												{selectedSkills.map((skill) => (
+													<Fragment key={skill.skillId}>
+														<SortableTag
+															id={skill.skillId}
+															tag={skill}
+															onRemove={handleSkillToggle}
+														/>
+													</Fragment>
+												))}
+											</div>
+										</SortableContext>
+									</DndContext>
+
+
+									<div id="clear-all-button-align">
+										<button
+											type="button"
+											className="delete-position-button-alt button-reset"
+											onClick={() => {
+												setSelectedSkills([]);
+												setSelectedSkillIds([]);
+											}}
+
+											title="Remove all selected tags"
+										>
+											<div id="clear-all-trash-row">
+												<p id="clear-all-trash-text">Clear All</p>
+												<ThemeIcon
+													id="trash"
+													width={18}
+													height={18}
+													ariaLabel="Delete position"
 												/>
-											</Fragment>
-										))}
+											</div>
+										</button>
 									</div>
-								</SortableContext>
-							</DndContext>
-
-
-							<div id="clear-all-button-align">
-								<button
-									type="button"
-									className="delete-position-button-alt button-reset"
-									onClick={() => {
-										setSelectedSkills([]);
-										setSelectedSkillIds([]);
-									}}
-
-									title="Remove all selected tags"
+								</div>
+							</DropdownContent>
+						</Dropdown> :
+							<div id="project-editor-selected-tags">
+								<div className="project-editor-section-header">
+									Selected Skills
+								</div>
+								<div className="project-editor-extra-info">
+									{selectedSkills.length <= 0 ? 'Skills that you select will appear here' : 'Drag and drop to reorder'}
+								</div>
+								<DndContext
+									sensors={sensors}
+									collisionDetection={closestCenter}
+									onDragEnd={handleDragEnd}
 								>
-									<div id="clear-all-trash-row">
-										<p id="clear-all-trash-text">Clear All</p>
-										<ThemeIcon
-											id="trash"
-											width={18}
-											height={18}
-											ariaLabel="Delete position"
-										/>
-									</div>
-								</button>
-							</div>
-						</div>
+									<SortableContext
+										items={selectedSkills.map((t) => t.skillId)}
+										strategy={verticalListSortingStrategy}
+									>
+										<div id="project-editor-selected-tags-container">
+											{selectedSkills.map((skill) => (
+												<Fragment key={skill.skillId}>
+													<SortableTag
+														id={skill.skillId}
+														tag={skill}
+														onRemove={handleSkillToggle}
+													/>
+												</Fragment>
+											))}
+										</div>
+									</SortableContext>
+								</DndContext>
+
+								<div id="clear-all-button-align">
+									<button
+										type="button"
+										className="delete-position-button-alt button-reset"
+										onClick={() => {
+											setSelectedSkills([]);
+											setSelectedSkillIds([]);
+										}}
+
+										title="Remove all selected tags"
+									>
+										<div id="clear-all-trash-row">
+											<p id="clear-all-trash-text">Clear All</p>
+											<ThemeIcon
+												id="trash"
+												width={18}
+												height={18}
+												ariaLabel="Delete position"
+											/>
+										</div>
+									</button>
+								</div>
+							</div>}
 						<div id="project-editor-tag-search">
 							<SearchBar
 								key={currentSkillsTab}

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -319,9 +319,6 @@ Login and Signup page style rules
 }
 
 @media screen and (max-width:500px) and (max-height:900px) {
-  .login-signup-container {
-    margin-bottom: 200px;
-  }
 
   .signup-form {
     padding: 0 25px;

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -394,6 +394,7 @@ Signup process modal style rules
   height: fit-content;
   max-height: 85vh;
   width: min(calc(90vw - 20px), 1055px);
+  max-width: 95vw;
   border-radius: 4px;
   padding: 0px;
   box-shadow: 0px 0px 10px 0px var(--border-color);

--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -422,7 +422,7 @@ Signup process modal style rules
 
 .ChooseSkills #profile-editor-tags {
   width: 90%;
-  overflow-y: hidden;
+  overflow-y: scroll;
   display: flex;
 
   #project-editor-tag-wrapper,
@@ -433,6 +433,30 @@ Signup process modal style rules
 
   #project-editor-tag-wrapper {
     min-height: 36px;
+  }
+
+  /* The Choose Skills dropdown container for MOBILE */
+  /* Make sure to only edit CSS here to maintain consistency for non-mobile devices */
+  .dropdown-container, #choose-skills-select-dropdown {
+    width: 100%;
+    text-align: left;
+    order: 2;
+
+    .dropdown, #project-editor-selected-tags {
+      width: calc(100% - 10px);
+    }
+    
+    /* The dropdown button */
+    #choose-skills-select-dropdown {
+      border-radius: 10px;
+      background-color: var(--bg-color);
+      border: 1px solid var(--border-color);
+      display: flex;
+      justify-content: space-between;
+      padding: 0 20px;
+      align-items: center;
+    }
+    height: 45px; /* matches dropdown containers on CompleteProfile.tsx */
   }
 }
 
@@ -1261,7 +1285,8 @@ Signup process modal style rules
     /* prevents x scrollbar */
 
     #project-editor-tag-search {
-      height: 80%;
+      height: auto;
+      max-height: 80%;
       overflow-y: scroll;
       max-width: auto;
       gap: 10px;
@@ -1309,7 +1334,7 @@ Signup process modal style rules
     padding: 0 !important;
 
     #project-editor-selected-tags {
-      width: calc(100% - 62px - 1.818px);
+      width: 100%;
       overflow-y: scroll;
       flex-shrink: 1;
 


### PR DESCRIPTION
Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/2600
Closes https://github.com/LookingforGrp-rit/LookingForGroup/issues/2598
(Since the Welcome task was short I figured I'd do both in 1 branch)

Proposed changes for Selected Skills section for Choose Skills signup:

Desktop looks the same as seen below
<img width="1507" height="866" alt="image" src="https://github.com/user-attachments/assets/f75ef929-61bd-4ae9-9ba7-9db961af15f5" />


For mobile, I made selected skills a dropdown so the tag search section is more easily viewed + selected tags doesnt take up as much space

Dropdown closed (default)
<img width="442" height="780" alt="image" src="https://github.com/user-attachments/assets/60d28385-4fb8-490a-8d9f-fb4f107de5e0" />

Dropdown open w/ skills selected
<img width="442" height="772" alt="image" src="https://github.com/user-attachments/assets/94b784c5-4390-4292-8d6d-f4d5977fac7d" />

Caveat: Because skills aren't a direct child of the dropdown container, clicking on skills causes the dropdown to close. This could become a UX problem later on, but I'm unsure how to fix this without major restructuring.