### PR TITLE
Fixed unapprove project trigger bugs and updated project saving confirmation popup text

### DIFF
--- a/client/src/api/data-managers/project-data-manager.ts
+++ b/client/src/api/data-managers/project-data-manager.ts
@@ -238,11 +238,15 @@ export const projectDataManager = async (projectId: number) => {
 
     // project fields
     try {
-      await runAndCollectErrors<UpdateProjectInput>(
-        "Updating project",
-        [updates.fields],
-        ({ data }) => updateProject(projectId, data)
-      );
+      const hasProjectFieldChanges = Object.keys(updates.fields.data ?? {}).length > 0;
+
+      if (hasProjectFieldChanges) {
+        await runAndCollectErrors<UpdateProjectInput>(
+          "Updating project",
+          [updates.fields],
+          ({ data }) => updateProject(projectId, data)
+        );
+      }
     } catch (error) {
       errorMessage += (error as { message: string }).message;
     }

--- a/client/src/components/ImageVideoDisplay.tsx
+++ b/client/src/components/ImageVideoDisplay.tsx
@@ -62,7 +62,7 @@ const ImageVideoDisplay = <Image extends (ProjectImage | PendingProjectImage) | 
   const [videoPopupOpen, setVideoPopupOpen] = useState(false);
 
   const [newVideo, setNewVideo] = useState<Video>({} as Video);
- 
+
   const [confirm, setConfirm] = useState(false);
 
   return (
@@ -142,7 +142,7 @@ const ImageVideoDisplay = <Image extends (ProjectImage | PendingProjectImage) | 
                     ariaLabel="change thumbnail"
                     onClick={() => handleThumbnailChange?.(projectImage as ProjectImage | PendingProjectImage)}
                   />
-              : "" }
+                : ""}
 
               {/* Delete icon */}
               <ThemeIcon
@@ -284,31 +284,39 @@ const ImageVideoDisplay = <Image extends (ProjectImage | PendingProjectImage) | 
                 <div id="invalid-input-error" className={"save-error-msg-general"}>
                   <p>*{message}*</p>
                 </div>}
-                {
-                  // Switches out the save button for a loading icon if the project is saving
-                  isSaving ? 
+              {
+                // Switches out the save button for a loading icon if the project is saving
+                isSaving ?
                   (
                     // Currently Saving
                     <div className='spinning-loader'></div>
                   ) : (
                     // Save is complete or hasn't been pressed
                     <PopupButton
-                    buttonId="project-editor-save"
-                    callback={() => {
-                      // Incomplete form: still clickable so the save validation runs,
-                      // shows the error, and auto-scrolls to the first missing field.
-                      if (!saveable) saveProject();
-                      else setConfirm(true);
-                    }}
-                  >
-                    Save Changes
-                  </PopupButton>
-                )
+                      buttonId="project-editor-save"
+                      callback={() => {
+                        // Incomplete form: still clickable so the save validation runs,
+                        // shows the error, and auto-scrolls to the first missing field.
+                        if (!saveable) saveProject();
+                        else setConfirm(true);
+                      }}
+                    >
+                      Save Changes
+                    </PopupButton>
+                  )
               }
-                          
+
               {confirm ?
                 <PopupContent useClose={false} callback={() => setConfirm(false)}>
-                  <div id="confirm-editor-save-text">Are you sure you want to save all changes?</div>
+                  <div id="confirm-editor-save-text">
+                    Are you sure you want to save all changes?
+                    {project?.approved &&
+                      <p id="unapproved-warning">
+                        <i className="fa-solid fa-triangle-exclamation"></i>
+                        Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                      </p>
+                    }
+                  </div>
                   <div id="confirm-editor-save">
                     <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save">
                       Confirm
@@ -317,26 +325,26 @@ const ImageVideoDisplay = <Image extends (ProjectImage | PendingProjectImage) | 
                       Cancel
                     </PopupButton>
                   </div>
-                </PopupContent> : "" 
+                </PopupContent> : ""
               }
             </Popup>
             {
-            // Hides the delete project button if the project is currently saving
-            isSaving ?
-            (
-              // Just here for blank space and to prevent 
-              // accidental deletion while a project is saving
-              ""
-            ) : (
-              <DeleteProjectButton
-                projectID={project?.projectId}
-                projectTitle={project?.title}
-              />
-            )
+              // Hides the delete project button if the project is currently saving
+              isSaving ?
+                (
+                  // Just here for blank space and to prevent 
+                  // accidental deletion while a project is saving
+                  ""
+                ) : (
+                  <DeleteProjectButton
+                    projectID={project?.projectId}
+                    projectTitle={project?.title}
+                  />
+                )
             }
           </div>
         </div>
-      : ""}
+        : ""}
     </div>
   );
 }

--- a/client/src/components/ImageVideoDisplay.tsx
+++ b/client/src/components/ImageVideoDisplay.tsx
@@ -310,10 +310,10 @@ const ImageVideoDisplay = <Image extends (ProjectImage | PendingProjectImage) | 
                 <PopupContent useClose={false} callback={() => setConfirm(false)}>
                   <div id="confirm-editor-save-text">
                     Are you sure you want to save all changes?
-                    {project?.approved &&
+                    {project && project.approved &&
                       <p id="unapproved-warning">
                         <i className="fa-solid fa-triangle-exclamation"></i>
-                        Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                        Changes to the General tab, or adding or updating Media or Links, will unapprove your project. You'll need to submit it for review again before it can be approved.
                       </p>
                     }
                   </div>

--- a/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
@@ -357,7 +357,7 @@ export const GeneralTab = ({
                   {projectData.approved &&
                     <p id="unapproved-warning">
                       <i className="fa-solid fa-triangle-exclamation"></i>
-                      Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                      Changes to the General tab, or adding or updating Media or Links, will unapprove your project. You'll need to submit it for review again before it can be approved.
                     </p>
                   }
                 </div>

--- a/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/GeneralTab.tsx
@@ -30,11 +30,11 @@ type GeneralTabProps = {
   unmodifiedProject: ProjectWithFollowers;
   saveProject?: () => Promise<void>;
   updatePendingProject?: (updatedPendingProject: PendingProject) => void;
-  saveable : boolean;
+  saveable: boolean;
   failCheck: boolean;
   updateFailCheck: boolean;
   message: string;
-  isSaving : boolean;
+  isSaving: boolean;
 };
 
 /**
@@ -53,8 +53,8 @@ export const GeneralTab = ({
   dataManager,
   projectData,
   unmodifiedProject,
-  saveProject = async () => {},
-  updatePendingProject = () => {},
+  saveProject = async () => { },
+  updatePendingProject = () => { },
   saveable,
   failCheck,
   updateFailCheck,
@@ -63,7 +63,7 @@ export const GeneralTab = ({
 }: GeneralTabProps) => {
 
   projectAfterGeneralChanges = structuredClone(projectData);
-  
+
   const projectId = projectData.projectId!;
   const saveButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -317,69 +317,77 @@ export const GeneralTab = ({
       />
       <div id="general-save-info">
         <div className="editor-save-actions">
-        <Popup>
-          {saveable ? "" :
-          <div id="invalid-input-error" className={"save-error-msg-general"}>
-            <p>*{message}*</p>
-          </div>}
+          <Popup>
+            {saveable ? "" :
+              <div id="invalid-input-error" className={"save-error-msg-general"}>
+                <p>*{message}*</p>
+              </div>}
+
+            {
+              // Switches out the save button for a loading icon if the project is saving
+              isSaving ?
+                (
+                  // Currently Saving
+                  <div className='spinning-loader'></div>
+                ) : (
+                  // Save is complete or hasn't been pressed
+                  <PopupButton
+                    buttonId="project-editor-save"
+                    callback={() => {
+                      // Incomplete form: still clickable so the save validation runs,
+                      // shows the error, and auto-scrolls to the first missing field.
+                      if (!saveable) {
+                        saveProject?.();
+                        return;
+                      }
+                      else setConfirm(true);
+                      console.log(`Current save ref: ${saveButtonRef.current}`);
+                      saveButtonRef.current?.focus();
+                    }}
+                  >
+                    Save Changes
+                  </PopupButton>
+                )
+            }
+
+            {confirm ?
+              <PopupContent useClose={false} callback={() => setConfirm(false)}>
+                <div id="confirm-editor-save-text">
+                  Are you sure you want to save all changes?
+                  {projectData.approved &&
+                    <p id="unapproved-warning">
+                      <i className="fa-solid fa-triangle-exclamation"></i>
+                      Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                    </p>
+                  }
+                </div>
+                <div id="confirm-editor-save">
+                  <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save"
+                    ref={saveButtonRef} >
+                    Confirm
+                  </PopupButton>
+                  <PopupButton buttonId="team-edit-member-cancel-button">
+                    Cancel
+                  </PopupButton>
+                </div>
+              </PopupContent> : ""
+            }
+          </Popup>
 
           {
-            // Switches out the save button for a loading icon if the project is saving
-            isSaving ? 
-            (
-              // Currently Saving
-              <div className='spinning-loader'></div>
-            ) : (
-              // Save is complete or hasn't been pressed
-              <PopupButton
-                buttonId="project-editor-save"
-                callback={() => {
-                  // Incomplete form: still clickable so the save validation runs,
-                  // shows the error, and auto-scrolls to the first missing field.
-                  if (!saveable) {
-                    saveProject?.();
-                    return;
-                  }
-                  else setConfirm(true);
-                  console.log(`Current save ref: ${saveButtonRef.current}`);
-                  saveButtonRef.current?.focus();
-                }}
-              >
-                Save Changes
-              </PopupButton>
-            )
+            // Hides the delete project button if the project is currently saving
+            isSaving ?
+              (
+                // Just here for blank space and to prevent 
+                // accidental deletion while a project is saving
+                ""
+              ) : (
+                <DeleteProjectButton
+                  projectID={unmodifiedProject.projectId}
+                  projectTitle={unmodifiedProject.title}
+                />
+              )
           }
-        
-          {confirm ?
-            <PopupContent useClose={false} callback={() => setConfirm(false)}>
-              <div id="confirm-editor-save-text">Are you sure you want to save all changes?</div>
-              <div id="confirm-editor-save">
-                <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save"
-                    ref={saveButtonRef} >
-                  Confirm
-                </PopupButton>
-                <PopupButton buttonId="team-edit-member-cancel-button">
-                  Cancel
-                </PopupButton>
-              </div>
-            </PopupContent> : ""
-          }
-        </Popup>
-        
-        {
-          // Hides the delete project button if the project is currently saving
-          isSaving ?
-          (
-            // Just here for blank space and to prevent 
-            // accidental deletion while a project is saving
-            ""
-          ) : (
-            <DeleteProjectButton
-              projectID={unmodifiedProject.projectId}
-              projectTitle={unmodifiedProject.title}
-            />
-          )
-        }
         </div>
       </div>
 

--- a/client/src/components/ProjectCreatorEditor/tabs/LinksTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/LinksTab.tsx
@@ -472,7 +472,7 @@ export const LinksTab = ({
                   {projectData.approved &&
                     <p id="unapproved-warning">
                       <i className="fa-solid fa-triangle-exclamation"></i>
-                      Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                      Changes to the General tab, or adding or updating Media or Links, will unapprove your project. You'll need to submit it for review again before it can be approved.
                     </p>
                   }
                 </div>

--- a/client/src/components/ProjectCreatorEditor/tabs/LinksTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/LinksTab.tsx
@@ -394,21 +394,21 @@ export const LinksTab = ({
                 onChange={(e) => handleSocialChange(index, 'url', e.target.value, url)}
               />
               <div id="clear-all-trash-row">
-              <button
-                type="button"
-                className="delete-position-button-alt button-reset"
-                onClick={() => handleDeleteSocial(index)}
-                title="Remove social link"
-              >
-                <div id="clear-all-trash-row">
-                <ThemeIcon
-                  id="trash"
-                  width={18}
-                  height={18}
-                  ariaLabel="Delete position"
-                />
-                </div>
-              </button>
+                <button
+                  type="button"
+                  className="delete-position-button-alt button-reset"
+                  onClick={() => handleDeleteSocial(index)}
+                  title="Remove social link"
+                >
+                  <div id="clear-all-trash-row">
+                    <ThemeIcon
+                      id="trash"
+                      width={18}
+                      height={18}
+                      ariaLabel="Delete position"
+                    />
+                  </div>
+                </button>
               </div>
             </div>
           );
@@ -437,63 +437,71 @@ export const LinksTab = ({
       </div>
       <div id="link-save-info">
         <div className="editor-save-actions">
-        <Popup>
-          {saveable ? "" :
-          <div id="invalid-input-error" className={"save-error-msg-general"}>
-            <p>*{message}*</p>
-          </div>}
+          <Popup>
+            {saveable ? "" :
+              <div id="invalid-input-error" className={"save-error-msg-general"}>
+                <p>*{message}*</p>
+              </div>}
+            {
+              // Switches out the save button for a loading icon if the project is saving
+              isSaving ?
+                (
+                  // Currently Saving
+                  <div className='spinning-loader'></div>
+                ) : (
+                  // Save is complete or hasn't been pressed
+                  <PopupButton
+                    buttonId="project-editor-save"
+                    callback={() => {
+                      // Incomplete form: still clickable so the save validation runs,
+                      // shows the error, and auto-scrolls to the first missing field.
+                      if (!saveable) saveProject?.();
+                      else setConfirm(true);
+                    }}
+                  >
+                    Save Changes
+                  </PopupButton>
+                )
+
+            }
+
+            {confirm ?
+              <PopupContent useClose={false} callback={() => setConfirm(false)}>
+                <div id="confirm-editor-save-text">
+                  Are you sure you want to save all changes?
+                  {projectData.approved &&
+                    <p id="unapproved-warning">
+                      <i className="fa-solid fa-triangle-exclamation"></i>
+                      Saving changes to the General, Media, or Links tabs will unapprove your project and require you to submit it for review again before it can be approved.
+                    </p>
+                  }
+                </div>
+                <div id="confirm-editor-save">
+                  <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save">
+                    Confirm
+                  </PopupButton>
+                  <PopupButton buttonId="team-edit-member-cancel-button" >
+                    Cancel
+                  </PopupButton>
+                </div>
+              </PopupContent> : ""
+            }
+          </Popup>
+
           {
-            // Switches out the save button for a loading icon if the project is saving
-            isSaving ? 
-            (
-              // Currently Saving
-              <div className='spinning-loader'></div>
-            ) : (
-              // Save is complete or hasn't been pressed
-              <PopupButton
-                buttonId="project-editor-save"
-                callback={() => {
-                  // Incomplete form: still clickable so the save validation runs,
-                  // shows the error, and auto-scrolls to the first missing field.
-                    if (!saveable) saveProject?.();
-                    else setConfirm(true);
-                }}
-              >
-                Save Changes
-              </PopupButton>
-            )
-
+            // Hides the delete project button if the project is currently saving
+            isSaving ?
+              (
+                // Just here for blank space and to prevent 
+                // accidental deletion while a project is saving
+                ""
+              ) : (
+                <DeleteProjectButton
+                  projectID={unmodifiedProject.projectId}
+                  projectTitle={unmodifiedProject.title}
+                />
+              )
           }
-
-          {confirm ?
-            <PopupContent useClose={false} callback={() => setConfirm(false)}>
-              <div id="confirm-editor-save-text">Are you sure you want to save all changes?</div>
-              <div id="confirm-editor-save">
-                <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save">
-                  Confirm
-                </PopupButton>
-                <PopupButton buttonId="team-edit-member-cancel-button" >
-                  Cancel
-                </PopupButton>
-              </div>
-            </PopupContent> : "" 
-          }
-        </Popup>
-
-        {
-          // Hides the delete project button if the project is currently saving
-          isSaving ?
-          (
-            // Just here for blank space and to prevent 
-            // accidental deletion while a project is saving
-            ""
-          ) : (
-            <DeleteProjectButton
-              projectID={unmodifiedProject.projectId}
-              projectTitle={unmodifiedProject.title}
-            />
-          )
-        }
         </div>
       </div>
     </div>

--- a/client/src/components/ProjectCreatorEditor/tabs/TagsTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/TagsTab.tsx
@@ -567,7 +567,15 @@ export const TagsTab = ({
 
             {confirm ?
               <PopupContent useClose={false} callback={() => setConfirm(false)}>
-                <div id="confirm-editor-save-text">Are you sure you want to save all changes?</div>
+                <div id="confirm-editor-save-text">
+                  Are you sure you want to save all changes?
+                  {projectData.approved &&
+                    <p id="unapproved-warning">
+                      <i className="fa-solid fa-triangle-exclamation"></i>
+                      Changes to the General tab, or adding or updating Media or Links, will unapprove your project. You'll need to submit it for review again before it can be approved.
+                    </p>
+                  }
+                </div>
                 <div id="confirm-editor-save">
                   <PopupButton callback={saveProject} closeParent={closeOuterPopup} buttonId="project-editor-save">
                     Confirm

--- a/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
+++ b/client/src/components/ProjectCreatorEditor/tabs/TeamTab.tsx
@@ -278,7 +278,7 @@ export const TeamTab = ({
 
 	const { setOpen: closeOuterPopup } = useContext(PopupContext);
 	const { setOpen } = useContext(PopupContext);
-	
+
 	// Check if the Pending Requests tab is unsaved
 	const isPendingRequestsUnsaved = useMemo(() => {
 		const currentInvitations = pendingInvitations || [];
@@ -1945,8 +1945,8 @@ export const TeamTab = ({
 	// Check if team tab is in edit mode
 	const positionWindow =
 		editMode === true ? positionEditWindow : positionViewWindow;
-	
-		// Renders the current member requests interface with member cards and edit functionality.
+
+	// Renders the current member requests interface with member cards and edit functionality.
 	const currentRequestsContent: JSX.Element = useMemo(
 		() => (
 			<div id="project-editor-project-requests">
@@ -2214,7 +2214,7 @@ export const TeamTab = ({
 							}}
 						/>
 						<div className="project-editor-project-member-info">
-							{projectAfterTeamChanges.owner.userId === member.user?.userId ? <ThemeIcon id={'owner-crown'} width={18} height={18} className={'color-fill'} ariaLabel="Project Owner"/> : ""}
+							{projectAfterTeamChanges.owner.userId === member.user?.userId ? <ThemeIcon id={'owner-crown'} width={18} height={18} className={'color-fill'} ariaLabel="Project Owner" /> : ""}
 							<div className="project-editor-project-member-name">
 								{member.user?.firstName} {member.user?.lastName}
 							</div>
@@ -2388,7 +2388,7 @@ export const TeamTab = ({
 												updatePendingProject(
 													projectAfterTeamChanges
 												);
-                        setErrorAddMember("");
+												setErrorAddMember("");
 											}}>
 											Save
 										</PopupButton>
@@ -2736,92 +2736,92 @@ export const TeamTab = ({
 		]
 	);
 
-  const projectOwnershipContent: JSX.Element = useMemo(() => 
-    <div id="project-editor-change-owner">
-      <div
-        key={projectAfterTeamChanges.owner.userId}
-        className="project-editor-owner-info"
-      >
-        <label>Current Owner</label>
-        <div className="project-editor-project-owner-extra">
-          <div id="owner-name">
-            {projectAfterTeamChanges.owner.firstName} {projectAfterTeamChanges.owner.lastName}
-          </div>
-          <div id="owner-user">
-            {projectAfterTeamChanges.owner.username}
-          </div>
-        </div>
-        <img
-          className="project-owner-image"
-          src={projectAfterTeamChanges.owner.profileImage ?? profileImage}
-          alt="profile image"
-          title={"Profile picture"}
-          // Cannot use usePreloadedImage function because this is in a callback
-          onError={(e) => {
-            const profileImg = e.target as HTMLImageElement;
-            profileImg.src = profileImage;
-          }}
-        />
-      </div>
-      {unmodifiedProject.owner.userId === currentUserId ? 
-        <div id="project-editor-owner-options">
-          <label>Change Owner To...</label>
-            <Select>
-              <SelectButton
-                placeholder="Select"
-                initialVal=""
-                type="input"
-                searchable={true}
-              />
-              <SelectOptions
-                callback={(e) => {
-                  setNewOwner(allUsers.find(user => user.userId === Number.parseInt((e.target as HTMLButtonElement).value)) ?? null)
-                }}
-                options={
-                projectAfterTeamChanges.members
-                .filter(m => m.user?.userId !== projectAfterTeamChanges.owner.userId)
-                .map((member) => {
-                  return {
-                    markup: <>
-                      <p className="user-search-name">
-                        {member.user?.firstName}{" "}
-                        {member.user?.lastName}
-                      </p>
-                      <p className="user-search-username">
-                        {member.user?.username}
-                      </p></>,
-                    value: member.user?.userId + "",
-                    disabled: false
-                  };
-                })}
-              />
-            </Select>
-          {newOwner?.userId !== projectAfterTeamChanges.owner.userId ? 
-            <div id="project-editor-owner-confirm">
-              <label>Confirm</label>
-              <button id="change-owner-confirm"
-              onClick={() => {
-                if (newOwner) {
-                  dataManager?.swapOwner({
-                    id: {
-                      type: "canon",
-                      value: newOwner.userId,
-                    },
-                    data: newOwner.userId,
-                  });
-                  projectAfterTeamChanges.owner = newOwner;
-                  updatePendingProject(projectAfterTeamChanges);
-                }
-              }}
-              >
-                Change Ownership
-              </button>
-            </div> 
-          : <></>}
-        </div>
-      : <></>}
-    </div>
-  , [projectAfterTeamChanges, currentUserId, searchBarKey, newOwner, searchResults]);
+	const projectOwnershipContent: JSX.Element = useMemo(() =>
+		<div id="project-editor-change-owner">
+			<div
+				key={projectAfterTeamChanges.owner.userId}
+				className="project-editor-owner-info"
+			>
+				<label>Current Owner</label>
+				<div className="project-editor-project-owner-extra">
+					<div id="owner-name">
+						{projectAfterTeamChanges.owner.firstName} {projectAfterTeamChanges.owner.lastName}
+					</div>
+					<div id="owner-user">
+						{projectAfterTeamChanges.owner.username}
+					</div>
+				</div>
+				<img
+					className="project-owner-image"
+					src={projectAfterTeamChanges.owner.profileImage ?? profileImage}
+					alt="profile image"
+					title={"Profile picture"}
+					// Cannot use usePreloadedImage function because this is in a callback
+					onError={(e) => {
+						const profileImg = e.target as HTMLImageElement;
+						profileImg.src = profileImage;
+					}}
+				/>
+			</div>
+			{unmodifiedProject.owner.userId === currentUserId ?
+				<div id="project-editor-owner-options">
+					<label>Change Owner To...</label>
+					<Select>
+						<SelectButton
+							placeholder="Select"
+							initialVal=""
+							type="input"
+							searchable={true}
+						/>
+						<SelectOptions
+							callback={(e) => {
+								setNewOwner(allUsers.find(user => user.userId === Number.parseInt((e.target as HTMLButtonElement).value)) ?? null)
+							}}
+							options={
+								projectAfterTeamChanges.members
+									.filter(m => m.user?.userId !== projectAfterTeamChanges.owner.userId)
+									.map((member) => {
+										return {
+											markup: <>
+												<p className="user-search-name">
+													{member.user?.firstName}{" "}
+													{member.user?.lastName}
+												</p>
+												<p className="user-search-username">
+													{member.user?.username}
+												</p></>,
+											value: member.user?.userId + "",
+											disabled: false
+										};
+									})}
+						/>
+					</Select>
+					{newOwner?.userId !== projectAfterTeamChanges.owner.userId ?
+						<div id="project-editor-owner-confirm">
+							<label>Confirm</label>
+							<button id="change-owner-confirm"
+								onClick={() => {
+									if (newOwner) {
+										dataManager?.swapOwner({
+											id: {
+												type: "canon",
+												value: newOwner.userId,
+											},
+											data: newOwner.userId,
+										});
+										projectAfterTeamChanges.owner = newOwner;
+										updatePendingProject(projectAfterTeamChanges);
+									}
+								}}
+							>
+								Change Ownership
+							</button>
+						</div>
+						: <></>}
+				</div>
+				: <></>}
+		</div>
+		, [projectAfterTeamChanges, currentUserId, searchBarKey, newOwner, searchResults]);
 
 	// Set content depending on what tab is selected
 	const teamTabContent =
@@ -2832,8 +2832,8 @@ export const TeamTab = ({
 		) : currentTeamTab === 2 ? (
 			openPositionsContent
 		) : currentTeamTab === 3 ? (
-      projectOwnershipContent
-    ) : (
+			projectOwnershipContent
+		) : (
 			<></>
 		);
 
@@ -2919,28 +2919,34 @@ export const TeamTab = ({
 						{
 							// Switches out the save button for a loading icon if the project is saving
 							isSaving ?
-							(
-								// Currently Saving
-								<div className='spinning-loader'></div>
-							) : (
-								// Save is complete or hasn't been pressed
-								<PopupButton
-									buttonId="project-editor-save"
-									callback={() => {
-										// Incomplete form: still clickable so the save validation
-										// runs, shows the error, and auto-scrolls to the missing field.
-										if (!saveable) saveProject?.();
-										else setConfirm(true)
-									}}>
-									Save Changes
-								</PopupButton>
-							)
+								(
+									// Currently Saving
+									<div className='spinning-loader'></div>
+								) : (
+									// Save is complete or hasn't been pressed
+									<PopupButton
+										buttonId="project-editor-save"
+										callback={() => {
+											// Incomplete form: still clickable so the save validation
+											// runs, shows the error, and auto-scrolls to the missing field.
+											if (!saveable) saveProject?.();
+											else setConfirm(true)
+										}}>
+										Save Changes
+									</PopupButton>
+								)
 						}
 
 						{confirm ?
 							<PopupContent useClose={false} callback={() => setConfirm(false)}>
 								<div id="confirm-editor-save-text">
 									Are you sure you want to save all changes?
+									{projectData.approved &&
+										<p id="unapproved-warning">
+											<i className="fa-solid fa-triangle-exclamation"></i>
+											Changes to the General tab, or adding or updating Media or Links, will unapprove your project. You'll need to submit it for review again before it can be approved.
+										</p>
+									}
 								</div>
 								<div id="confirm-editor-save">
 									<PopupButton
@@ -2960,16 +2966,16 @@ export const TeamTab = ({
 					{
 						// Hides the delete project button if the project is currently saving
 						isSaving ?
-						(
-							// Just here for blank space and to prevent 
-							// accidental deletion while a project is saving
-							""
-						) : (
-							<DeleteProjectButton
-								projectID={unmodifiedProject.projectId}
-								projectTitle={unmodifiedProject.title}
-							/>
-						)
+							(
+								// Just here for blank space and to prevent 
+								// accidental deletion while a project is saving
+								""
+							) : (
+								<DeleteProjectButton
+									projectID={unmodifiedProject.projectId}
+									projectTitle={unmodifiedProject.title}
+								/>
+							)
 					}
 				</div>
 			</div>

--- a/client/src/components/Styles/projects.css
+++ b/client/src/components/Styles/projects.css
@@ -1644,6 +1644,19 @@ Project Creator and Editor Popup style rules
 #confirm-editor-save-text {
   padding: 50px;
   font-size: 1.25rem;
+
+  #unapproved-warning {
+    max-width: 50ch;
+    min-width: 10ch;
+    color: var(--primary-color);
+    font-weight: bold;
+    line-height: 1.5em;
+  }
+
+  .fa-triangle-exclamation {
+    color: #F59E0B;
+    padding-right: 10px;
+  }
 }
 
 #project-editor-project-members {

--- a/server/src/services/projects/socials/add-social.ts
+++ b/server/src/services/projects/socials/add-social.ts
@@ -3,6 +3,7 @@ import prisma from '#config/prisma.ts';
 import { ProjectSocialSelector } from '#services/selectors/projects/parts/project-social.ts';
 import type { ServiceErrorSubset } from '#services/service-outcomes.ts';
 import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
+import { unapproveProjectService } from '../approval/unapprove-project.ts';
 
 type AddProjectSocialServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND' | 'CONFLICT'>;
 
@@ -30,6 +31,16 @@ export const addProjectSocialService = async (
       },
       select: ProjectSocialSelector,
     });
+
+    const proj = await prisma.projects.findUnique({
+      where: {
+        projectId,
+      },
+    });
+
+    if (proj && proj.approved) {
+      await unapproveProjectService(proj.projectId);
+    }
 
     return transformProjectSocial(projectId, social);
   } catch (error) {

--- a/server/src/services/projects/socials/update-proj-social.ts
+++ b/server/src/services/projects/socials/update-proj-social.ts
@@ -14,35 +14,43 @@ export const updateProjectSocialService = async (
   socialId: number,
 ): Promise<ProjectSocial | UpdateProjectSocialServiceError> => {
   try {
-    //social validation (does it have this social)
-    const socialExists = await prisma.projectSocials.findUnique({
+    // social validation (does it have this social)
+    const social = await prisma.projectSocials.findUnique({
       where: {
         id: socialId,
       },
-    });
-    if (!socialExists) return 'NOT_FOUND';
-
-    const social = await prisma.projectSocials.update({
-      where: {
-        id: socialId,
-      },
-      data: data,
       select: ProjectSocialSelector,
     });
+    if (!social) return 'NOT_FOUND';
 
-    //find project for the approval stuff
-    const proj = await prisma.projects.findUnique({
-      where: {
-        projectId,
-      },
-    });
+    const socialChanged =
+      social.url !== data.url ||
+      social.alias !== data.alias ||
+      social.socials.websiteId !== data.websiteId;
 
-    //unapprove project on change
-    if (proj && proj.approved) {
-      await unapproveProjectService(proj.projectId);
+    const updatedSocial = socialChanged
+      ? await prisma.projectSocials.update({
+          where: {
+            id: socialId,
+          },
+          data: data,
+          select: ProjectSocialSelector,
+        })
+      : social;
+
+    if (socialChanged) {
+      const proj = await prisma.projects.findUnique({
+        where: {
+          projectId,
+        },
+      });
+
+      if (proj && proj.approved) {
+        await unapproveProjectService(proj.projectId);
+      }
     }
 
-    return transformProjectSocial(projectId, social);
+    return transformProjectSocial(projectId, updatedSocial);
   } catch (error) {
     console.error('Error in updateProjectSocialService:', error);
     return 'INTERNAL_ERROR';

--- a/server/src/services/projects/socials/update-proj-social.ts
+++ b/server/src/services/projects/socials/update-proj-social.ts
@@ -23,6 +23,7 @@ export const updateProjectSocialService = async (
     });
     if (!social) return 'NOT_FOUND';
 
+    // Check if social data changes
     const socialChanged =
       social.url !== data.url ||
       social.alias !== data.alias ||

--- a/server/src/services/projects/update-proj.ts
+++ b/server/src/services/projects/update-proj.ts
@@ -13,14 +13,27 @@ const updateProjectService = async (
   updates: Omit<UpdateProjectInput, 'thumbnail'>,
 ): Promise<ProjectDetail | UpdateProjectServiceError> => {
   try {
+    const currentProject = await prisma.projects.findUnique({
+      where: { projectId },
+    });
+
+    if (!currentProject) {
+      return 'NOT_FOUND';
+    }
+
+    const hasChanges = (Object.keys(updates) as (keyof typeof updates)[]).some(
+      (key) => currentProject[key] !== updates[key],
+    );
+
     //removed all the thumbnail stuff, that's handled elsewhere now
     const project = await prisma.projects.update({
       where: { projectId },
       data: updates,
       select: ProjectDetailSelector,
     });
+
     //unapprove project on change
-    if (project.approved) {
+    if (project.approved && hasChanges) {
       await unapproveProjectService(projectId);
     }
 

--- a/server/src/services/projects/videos/add-video.ts
+++ b/server/src/services/projects/videos/add-video.ts
@@ -1,6 +1,7 @@
 import prisma from '#config/prisma.ts';
 import type { Prisma } from '#prisma-models/index.js';
 import type { ServiceErrorSubset, ServiceSuccessSubset } from '#services/service-outcomes.ts';
+import { unapproveProjectService } from '../approval/unapprove-project.ts';
 
 type AddVideoServiceError = ServiceErrorSubset<'INTERNAL_ERROR' | 'NOT_FOUND'>;
 type AddVideoServiceSuccess = ServiceSuccessSubset<'CREATED'>;
@@ -12,9 +13,21 @@ const addVideoService = async (
 ): Promise<AddVideoServiceSuccess | AddVideoServiceError> => {
   try {
     //add video
-    await prisma.projectVideos.create({
+    const newVideo = await prisma.projectVideos.create({
       data,
     });
+
+    //find project for the approval stuff
+    const proj = await prisma.projects.findUnique({
+      where: {
+        projectId: newVideo.projectId,
+      },
+    });
+
+    //unapprove project on change
+    if (proj && proj.approved) {
+      await unapproveProjectService(proj.projectId);
+    }
 
     return 'CREATED';
   } catch (e) {

--- a/server/tests/metest/followings/add-follow-user.test.ts
+++ b/server/tests/metest/followings/add-follow-user.test.ts
@@ -53,6 +53,8 @@ const transformedUserPreview: UserPreview = {
   title: '',
   userId: 2,
   username: '',
+  skills: [],
+  ritStatus: 'FourthYear',
 };
 
 const prismaUserFollowing: MyFollowing = {

--- a/server/tests/projectstest/socials/add-social.test.ts
+++ b/server/tests/projectstest/socials/add-social.test.ts
@@ -87,7 +87,7 @@ describe('addProjectSocialService', async () => {
     expect(result).toBe(transformedSocial);
   });
 
-  it('returns the social when add is successful and does not do anything to the unapproved project', async () => {
+  it('returns the social when add is successful and does unapprove a not-approved project', async () => {
     vi.mocked(prisma.socials.findFirst).mockResolvedValue({ websiteId: 29, label: 'Test' });
     vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);

--- a/server/tests/projectstest/socials/add-social.test.ts
+++ b/server/tests/projectstest/socials/add-social.test.ts
@@ -1,12 +1,14 @@
 import type { AddProjectSocialInput, ProjectSocial } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
+import { unapproveProjectService } from '#services/projects/approval/unapprove-project.ts';
 import { addProjectSocialService } from '#services/projects/socials/add-social.ts';
 import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
 
 /* eslint-disable @typescript-eslint/unbound-method */
-
 /* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 vi.mock('#config/prisma.ts', () => ({
   default: {
@@ -17,11 +19,18 @@ vi.mock('#config/prisma.ts', () => ({
       findFirst: vi.fn(),
       create: vi.fn(),
     },
+    projects: {
+      findUnique: vi.fn(),
+    },
   },
 }));
 
 vi.mock('#services/transformers/projects/parts/project-social.ts', () => ({
   transformProjectSocial: vi.fn(),
+}));
+
+vi.mock('#services/projects/approval/unapprove-project.ts', () => ({
+  unapproveProjectService: vi.fn(),
 }));
 
 const data: AddProjectSocialInput = {
@@ -48,35 +57,67 @@ const transformedSocial: ProjectSocial = {
   apiUrl: 'api/project/1/socials/29',
 };
 
+const approvedProject = {
+  projectId: 1,
+  approved: true,
+};
+
+const unapprovedProject = {
+  projectId: 1,
+  approved: false,
+};
+
 describe('addProjectSocialService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-  it('returns the social when add is successful', async () => {
+
+  it('returns the social when add is successful and unapproves the approved project', async () => {
     vi.mocked(prisma.socials.findFirst).mockResolvedValue({ websiteId: 29, label: 'Test' });
     vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(approvedProject as any);
+    vi.mocked(unapproveProjectService).mockResolvedValue(unapprovedProject as any);
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+
     const result = await addProjectSocialService(data, 1);
 
     expect(transformProjectSocial).toHaveBeenCalled();
     expect(transformProjectSocial).toHaveBeenCalledWith(1, testSocial);
     expect(result).toBe(transformedSocial);
   });
+
+  it('returns the social when add is successful and does not do anything to the unapproved project', async () => {
+    vi.mocked(prisma.socials.findFirst).mockResolvedValue({ websiteId: 29, label: 'Test' });
+    vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(unapprovedProject as any);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+
+    const result = await addProjectSocialService(data, 1);
+
+    expect(transformProjectSocial).toHaveBeenCalled();
+    expect(transformProjectSocial).toHaveBeenCalledWith(1, testSocial);
+    expect(result).toBe(transformedSocial);
+  });
+
   it("returns NOT_FOUND when websiteId isn't found", async () => {
     vi.mocked(prisma.socials.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+
     const result = await addProjectSocialService(data, 1);
 
     expect(result).toBe('NOT_FOUND');
   });
+
   it('returns INTERNAL_ERROR when prisma throws', async () => {
     vi.mocked(prisma.socials.findFirst).mockRejectedValue(new Error('womp womp'));
     vi.mocked(prisma.projectSocials.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.projectSocials.create).mockResolvedValue(testSocial);
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+
     const result = await addProjectSocialService(data, 1);
 
     expect(result).toBe('INTERNAL_ERROR');

--- a/server/tests/projectstest/socials/update-proj-social.test.ts
+++ b/server/tests/projectstest/socials/update-proj-social.test.ts
@@ -70,6 +70,7 @@ describe('updateProjectSocialService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
   it('returns the social when update is successful', async () => {
     vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(testSocial as any);
     vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial as any);

--- a/server/tests/projectstest/socials/update-proj-social.test.ts
+++ b/server/tests/projectstest/socials/update-proj-social.test.ts
@@ -6,8 +6,9 @@ import { updateProjectSocialService } from '#services/projects/socials/update-pr
 import { transformProjectSocial } from '#services/transformers/projects/parts/project-social.ts';
 
 /* eslint-disable @typescript-eslint/unbound-method */
-
 /* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 vi.mock('#config/prisma.ts', () => ({
   default: {
@@ -41,9 +42,12 @@ const transformedSocial: ProjectSocial = {
 const testSocial = {
   id: 1,
   projectId: 1,
-  websiteId: 12,
   url: 'www.no-more-test.com',
   alias: 'Click here to ban test',
+  socials: {
+    websiteId: 12,
+    label: 'Test',
+  },
 };
 
 const prismaProject = {
@@ -62,13 +66,13 @@ const prismaProject = {
   approved: true,
 };
 
-describe('getProjectSocialsService', async () => {
+describe('updateProjectSocialService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
   it('returns the social when update is successful', async () => {
-    vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(testSocial);
-    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(testSocial as any);
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial as any);
     vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
     vi.mocked(unapproveProjectService).mockResolvedValue('OK');
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
@@ -88,7 +92,7 @@ describe('getProjectSocialsService', async () => {
 
   it("returns NOT_FOUND when social doesn't exist", async () => {
     vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(null);
-    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial as any);
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
     const result = await updateProjectSocialService(
       {
@@ -103,9 +107,41 @@ describe('getProjectSocialsService', async () => {
     expect(result).toEqual('NOT_FOUND');
   });
 
+  it('does not update or unapprove when no social data changes', async () => {
+    const unchangedSocial = {
+      id: 1,
+      projectId: 1,
+      url: 'www.no-more-test.com',
+      alias: 'Click here to ban test',
+      socials: {
+        websiteId: 12,
+        label: 'Test',
+      },
+    };
+
+    vi.mocked(prisma.projectSocials.findUnique).mockResolvedValue(unchangedSocial as any);
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
+    vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
+
+    const result = await updateProjectSocialService(
+      {
+        url: 'www.no-more-test.com',
+        websiteId: 12,
+        alias: 'Click here to ban test',
+      },
+      1,
+      1,
+    );
+
+    expect(prisma.projectSocials.update).not.toHaveBeenCalled();
+    expect(unapproveProjectService).not.toHaveBeenCalled();
+    expect(transformProjectSocial).toHaveBeenCalledWith(1, unchangedSocial);
+    expect(result).toEqual(transformedSocial);
+  });
+
   it('returns INTERNAL_ERROR when prisma throws', async () => {
     vi.mocked(prisma.projectSocials.findUnique).mockRejectedValue(new Error('womp womp'));
-    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial);
+    vi.mocked(prisma.projectSocials.update).mockResolvedValue(testSocial as any);
     vi.mocked(transformProjectSocial).mockReturnValue(transformedSocial);
     const result = await updateProjectSocialService(
       {

--- a/server/tests/projectstest/update-proj.test.ts
+++ b/server/tests/projectstest/update-proj.test.ts
@@ -105,7 +105,7 @@ const transformed: ProjectDetail = {
   approved: true,
 };
 
-describe('deleteProjectService', async () => {
+describe('updateProjectService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -120,7 +120,7 @@ describe('deleteProjectService', async () => {
     expect(result).toBe(transformed);
   });
 
-  it('does not unapprove for non-general project updates', async () => {
+  it('does not unapprove if no project data changes', async () => {
     vi.mocked(prisma.projects.findUnique).mockResolvedValue({ ...prismaProject, approved: true });
     vi.mocked(prisma.projects.update).mockResolvedValue({ ...prismaProject, approved: true });
     vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
@@ -130,7 +130,7 @@ describe('deleteProjectService', async () => {
     expect(unapproveProjectService).not.toHaveBeenCalled();
   });
 
-  it('unapproves when a general-field update changes approved project data', async () => {
+  it('unapproves when a field update changes approved project data', async () => {
     vi.mocked(prisma.projects.findUnique).mockResolvedValue({ ...prismaProject, approved: true });
     vi.mocked(prisma.projects.update).mockResolvedValue({ ...prismaProject, approved: true });
     vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
@@ -140,8 +140,16 @@ describe('deleteProjectService', async () => {
     expect(unapproveProjectService).toHaveBeenCalledWith(1);
   });
 
+  it('returns NOT_FOUND if project not found', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(null);
+
+    const result = await updateProjectService(1, projectUpdate);
+
+    expect(result).toBe('NOT_FOUND');
+  });
+
   it('returns INTERNAL_ERROR if prisma throws', async () => {
-    vi.mocked(prisma.projects.update).mockRejectedValue('db exploded :(');
+    vi.mocked(prisma.projects.findUnique).mockRejectedValue(new Error('db exploded :('));
     vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
     const result = await updateProjectService(1, projectUpdate);
 

--- a/server/tests/projectstest/update-proj.test.ts
+++ b/server/tests/projectstest/update-proj.test.ts
@@ -2,6 +2,7 @@ import type { UserPreview, ProjectDetail, UpdateProjectInput } from '@looking-fo
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import type { Projects } from '#prisma-models/index.js';
+import { unapproveProjectService } from '#services/projects/approval/unapprove-project.ts';
 import updateProjectService from '#services/projects/update-proj.ts';
 import { transformProjectToDetail } from '#services/transformers/projects/project-detail.ts';
 
@@ -12,10 +13,15 @@ vi.mock('#services/transformers/projects/project-detail.ts', () => ({
   transformProjectToDetail: vi.fn(),
 }));
 
+vi.mock('#services/projects/approval/unapprove-project.ts', () => ({
+  unapproveProjectService: vi.fn(),
+}));
+
 vi.mock('#config/prisma.ts', () => ({
   default: {
     projects: {
       update: vi.fn(),
+      findUnique: vi.fn(),
       findMany: vi.fn(),
     },
     projectImages: {
@@ -105,6 +111,7 @@ describe('deleteProjectService', async () => {
   });
 
   it('returns transformed if successful update', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(prismaProject);
     vi.mocked(prisma.projects.update).mockResolvedValue(prismaProject);
     vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
     const result = await updateProjectService(1, projectUpdate);
@@ -112,6 +119,27 @@ describe('deleteProjectService', async () => {
     expect(transformProjectToDetail).toHaveBeenCalledWith(prismaProject);
     expect(result).toBe(transformed);
   });
+
+  it('does not unapprove for non-general project updates', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue({ ...prismaProject, approved: true });
+    vi.mocked(prisma.projects.update).mockResolvedValue({ ...prismaProject, approved: true });
+    vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
+
+    await updateProjectService(1, { status: 'Planning' });
+
+    expect(unapproveProjectService).not.toHaveBeenCalled();
+  });
+
+  it('unapproves when a general-field update changes approved project data', async () => {
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue({ ...prismaProject, approved: true });
+    vi.mocked(prisma.projects.update).mockResolvedValue({ ...prismaProject, approved: true });
+    vi.mocked(transformProjectToDetail).mockReturnValue(transformed);
+
+    await updateProjectService(1, { title: 'New Title' });
+
+    expect(unapproveProjectService).toHaveBeenCalledWith(1);
+  });
+
   it('returns INTERNAL_ERROR if prisma throws', async () => {
     vi.mocked(prisma.projects.update).mockRejectedValue('db exploded :(');
     vi.mocked(transformProjectToDetail).mockReturnValue(transformed);

--- a/server/tests/projectstest/videos/add-video.test.ts
+++ b/server/tests/projectstest/videos/add-video.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import type { Prisma } from '#prisma-models/index.js';
+import { unapproveProjectService } from '#services/projects/approval/unapprove-project.ts';
 import addVideoService from '#services/projects/videos/add-video.ts';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const videoData: Prisma.ProjectVideosCreateInput = {
   videoUrl: 'www.test.com',
@@ -25,21 +28,51 @@ const prismaVideo = {
   videoId: 4,
 };
 
+const approvedProject = {
+  projectId: 1,
+  approved: true,
+};
+
+const unapprovedProject = {
+  projectId: 1,
+  approved: false,
+};
+
 vi.mock('#config/prisma.ts', () => ({
   default: {
     projectVideos: {
       create: vi.fn(),
       findMany: vi.fn(),
     },
+    projects: {
+      findUnique: vi.fn(),
+    },
   },
+}));
+
+vi.mock('#services/projects/approval/unapprove-project.ts', () => ({
+  unapproveProjectService: vi.fn(),
 }));
 
 describe('addVideoService', async () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-  it('returns CREATED if successful', async () => {
+
+  it('returns CREATED if successfully created the project and unapproves approved project', async () => {
     vi.mocked(prisma.projectVideos.create).mockResolvedValue(prismaVideo);
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(approvedProject as any);
+    vi.mocked(unapproveProjectService).mockResolvedValue(unapprovedProject as any);
+
+    const result = await addVideoService(videoData);
+
+    expect(result).toBe('CREATED');
+  });
+
+  it('returns CREATED if successfully created the project and do not unapprove a not-approved project', async () => {
+    vi.mocked(prisma.projectVideos.create).mockResolvedValue(prismaVideo);
+    vi.mocked(prisma.projects.findUnique).mockResolvedValue(unapprovedProject as any);
+
     const result = await addVideoService(videoData);
 
     expect(result).toBe('CREATED');

--- a/server/tests/userstest/blacklisttest/add-to-blacklist.test.ts
+++ b/server/tests/userstest/blacklisttest/add-to-blacklist.test.ts
@@ -13,10 +13,47 @@ vi.mock('#config/prisma.ts', () => ({
     },
     users: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
       update: vi.fn(),
     },
     session: {
       deleteMany: vi.fn(),
+    },
+    majors: {
+      findMany: vi.fn(),
+    },
+    blocklist: {
+      findMany: vi.fn(),
+    },
+    members: {
+      findMany: vi.fn(),
+    },
+    projectImages: {
+      findMany: vi.fn(),
+    },
+    roles: {
+      findMany: vi.fn(),
+    },
+    skills: {
+      findMany: vi.fn(),
+    },
+    jobSkills: {
+      findMany: vi.fn(),
+    },
+    jobs: {
+      findMany: vi.fn(),
+    },
+    mediums: {
+      findMany: vi.fn(),
+    },
+    tags: {
+      findMany: vi.fn(),
+    },
+    projects: {
+      findMany: vi.fn(),
+    },
+    projectsAwaitingApproval: {
+      findMany: vi.fn(),
     },
   },
 }));

--- a/server/tests/userstest/blacklisttest/get-blacklisted-users.test.ts
+++ b/server/tests/userstest/blacklisttest/get-blacklisted-users.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
+import { UserDetailSelector } from '#services/selectors/users/user-detail.ts';
 import { transformUserToDetail } from '#services/transformers/users/user-detail.ts';
 import { getBlacklistedUsersService } from '#services/users/blacklist/get-blacklisted-users.ts';
 
@@ -7,6 +8,7 @@ import { getBlacklistedUsersService } from '#services/users/blacklist/get-blackl
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 vi.mock('#config/prisma.ts', () => ({
   default: {
@@ -49,10 +51,12 @@ const transformed = [
   {
     userId: 1,
     username: 'user1',
+    firstName: 'user1',
   },
   {
     userId: 2,
     username: 'user2',
+    firstName: 'user2',
   },
 ];
 
@@ -64,7 +68,9 @@ describe('getBlacklistedUsersService', async () => {
   it('returns an array of blacklisted users if found', async () => {
     vi.mocked(prisma.userBlacklist.findMany).mockResolvedValue(prismaBlacklist);
     vi.mocked(prisma.users.findMany).mockResolvedValue(prismaUsers as any);
-    vi.mocked(transformUserToDetail).mockResolvedValue(transformed as any);
+    vi.mocked(transformUserToDetail).mockImplementation((user: { userId: number }) => {
+      return transformed.find((transformedUser) => transformedUser.userId === user.userId) as any;
+    });
 
     const result = await getBlacklistedUsersService();
 
@@ -75,6 +81,7 @@ describe('getBlacklistedUsersService', async () => {
           in: prismaBlacklist.map((b) => b.googleId),
         },
       },
+      select: UserDetailSelector,
     });
     expect(transformUserToDetail).toHaveBeenCalledTimes(prismaUsers.length);
     expect(result).toStrictEqual(transformed);

--- a/server/tests/userstest/followingstest/get-proj-following.test.ts
+++ b/server/tests/userstest/followingstest/get-proj-following.test.ts
@@ -1,4 +1,4 @@
-import type { ProjectFollowsList } from '@looking-for-group/shared';
+import type { ProjectFollowsList, RitStatus } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import type { Visibility } from '#prisma-models/index.js';
@@ -69,6 +69,8 @@ describe('getProjectFollowingService', () => {
         title: 'Test Title',
         location: 'Test Location',
         majors: [],
+        skills: [],
+        ritStatus: 'FifthYear' as RitStatus,
       },
       tags: [],
       thumbnail: {

--- a/server/tests/userstest/followingstest/get-user-followers.test.ts
+++ b/server/tests/userstest/followingstest/get-user-followers.test.ts
@@ -1,4 +1,4 @@
-import type { UserFollowsList, Visibility } from '@looking-for-group/shared';
+import type { UserFollowsList, Visibility, RitStatus } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import { transformUserToPreview } from '#services/transformers/users/user-preview.ts';
@@ -65,7 +65,6 @@ describe('getUserFollowersService', () => {
       pronouns: '',
       title: '',
       displayPhone: false,
-      ritStatus: null,
       location: '',
       bio: '',
       designer: false,
@@ -73,6 +72,8 @@ describe('getUserFollowersService', () => {
       privacy: 'public' as Visibility,
       majors: [],
       apiUrl: '/api/users/2',
+      skills: [],
+      ritStatus: 'FourthYear' as RitStatus,
     };
 
     vi.mocked(prisma.userFollowings.findMany).mockResolvedValue(prismaResult);

--- a/server/tests/userstest/followingstest/get-user-following.test.ts
+++ b/server/tests/userstest/followingstest/get-user-following.test.ts
@@ -1,4 +1,4 @@
-import type { ProjectFollowsList, Visibility } from '@looking-for-group/shared';
+import type { ProjectFollowsList, Visibility, RitStatus } from '@looking-for-group/shared';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '#config/prisma.ts';
 import type { Projects } from '#prisma-models/index.js';
@@ -75,6 +75,8 @@ describe('getProjectFollowingService', () => {
         majors: [],
         displayPhone: false,
         apiUrl: '/api/users/1',
+        skills: [],
+        ritStatus: 'FourthYear' as RitStatus,
       },
       thumbnail: null,
       thumbnailId: 0,

--- a/server/tests/userstest/getusertest/get-by-email.test.ts
+++ b/server/tests/userstest/getusertest/get-by-email.test.ts
@@ -49,6 +49,8 @@ describe('getUserByEmailService', () => {
       title: '',
       location: '',
       majors: [],
+      skills: [],
+      ritStatus: 'FifthYear',
     };
 
     vi.mocked(prisma.users.findFirst).mockResolvedValue(prismaUser as any);

--- a/server/tests/userstest/getusertest/get-by-username.test.ts
+++ b/server/tests/userstest/getusertest/get-by-username.test.ts
@@ -48,6 +48,8 @@ describe('getUserByUsernameService', () => {
       title: '',
       location: '',
       majors: [],
+      skills: [],
+      ritStatus: 'FourthYear',
     };
 
     vi.mocked(prisma.users.findFirst).mockResolvedValue(prismaUser as any);


### PR DESCRIPTION
## Frontend
Updated the project saving confirmation popup text to reflect that changes in the general, media, and links tab will unapprove the project if already approved and will need to submit another review request.
<img width="500" alt="Snapzy_2026-08-06_10-43-57_050" src="https://github.com/user-attachments/assets/fe744afe-42c6-4295-9f3a-3b2b41b95c78" />

## Backend
- Fixed related unit tests to reflect the unapproving project part
- Updated `update-proj-social.ts` and `update-proj.ts` to unapprove an approved project only if data has changed (sometimes, they are called bc another change. For example, changes in the team tab also call `updateLinks()` in `ProjectCreatorEditor.tsx`, so adding a check in both services prevents unexpected unapproval)
- Added the same unapproval logic to `add-video.ts` and `add-social.ts`
