### PR TITLE
Potential fix to off-centered Google button

### DIFF
--- a/client/src/components/Styles/loginSignup.css
+++ b/client/src/components/Styles/loginSignup.css
@@ -161,17 +161,20 @@ Login and Signup page style rules
 
 .signup-form-inputs,
 .login-form-inputs {
-  /* border: 1px solid black; */
   width: 100%;
   max-width: 320px;
   max-height: 340px;
   height: auto;
-  margin: 20px auto;
+  margin: 15px auto 20px auto; /* accounts for error message padding -- looks more centered */
   gap: 15px;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: stretch;
+  align-items: center;
+
+  #googleBtn {
+    align-self: stretch;
+  }
 }
 
 .signup-form p {

--- a/client/src/components/pages/Signup.tsx
+++ b/client/src/components/pages/Signup.tsx
@@ -415,7 +415,6 @@ const SignUp: React.FC<SignUpProps> = ({ /*setAvatarImage, avatarImage,*/ profil
             /> */}
 
             <div id="googleBtn"></div>
-            <span className="spacer"> </span>
             {/* <input
               className="signup-input"
               autoComplete="off"


### PR DESCRIPTION
I'm not sure if this fixed the issue because I can't directly test it on railway

This is now what it looks like in localhost:

<img width="1463" height="861" alt="image" src="https://github.com/user-attachments/assets/6371e327-4131-4045-bcd2-510ff23a4b93" />

Also removed the awkward spacer and centered the button more

Would close https://github.com/LookingforGrp-rit/LookingForGroup/issues/2251